### PR TITLE
Update userinput section of mobile roadmap

### DIFF
--- a/data/animation-frames.json
+++ b/data/animation-frames.json
@@ -1,4 +1,4 @@
 {
   "impl": {},
-  "TR": "https://www.w3.org/TR/html/webappapis.html#animation-frames"
+  "TR": "https://www.w3.org/TR/html51/webappapis.html#animation-frames"
 }

--- a/data/audio.json
+++ b/data/audio.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "audio"
   },
-  "TR": "https://www.w3.org/TR/html5/embedded-content-0.html#the-audio-element",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-audio-element",
   "feature": "audio element"
 }

--- a/data/autocomplete.json
+++ b/data/autocomplete.json
@@ -1,5 +1,5 @@
 {
   "impl": {},
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#element-attrdef-autocompleteelements-autocomplete",
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-autocompleteelements-autocomplete",
   "feature": "autocomplete attribute"
 }

--- a/data/css-scroll-snap.json
+++ b/data/css-scroll-snap.json
@@ -1,0 +1,6 @@
+{
+  "impl": {
+    "caniuse": "css-snappoints"
+  },
+  "TR": "https://www.w3.org/TR/css-scroll-snap-1/"
+}

--- a/data/css-touch-action.json
+++ b/data/css-touch-action.json
@@ -1,0 +1,7 @@
+{
+  "impl": {
+    "caniuse": "css-touch-action"
+  },
+  "TR": "https://www.w3.org/TR/pointerevents2/",
+  "feature": "touch-action"
+}

--- a/data/cssom-view.json
+++ b/data/cssom-view.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/cssom-view-1/"
+}

--- a/data/datalist.json
+++ b/data/datalist.json
@@ -4,6 +4,6 @@
     "chromestatus": 6090950820495360,
     "edgestatus": "<datalist> Element"
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#the-datalist-element",
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-datalist-element",
   "feature": "Datalist element"
 }

--- a/data/html5-download.json
+++ b/data/html5-download.json
@@ -4,6 +4,6 @@
     "chromestatus": 6473924464345088,
     "webkitstatus": "feature-download-attribute"
   },
-  "TR": "https://www.w3.org/TR/html5/links.html#attr-hyperlink-download",
+  "TR": "https://www.w3.org/TR/html51/links.html#downloading-resources",
   "feature" : "download attribute"
 }

--- a/data/htmlmediaelement.json
+++ b/data/htmlmediaelement.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html5/embedded-content-0.html#htmlmediaelement",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-media-elements",
   "feature": "HTMLMediaElement interface"
 }

--- a/data/ime-api.json
+++ b/data/ime-api.json
@@ -1,0 +1,6 @@
+{
+  "impl": {
+    "caniuse": "ime"
+  },
+  "TR": "https://www.w3.org/TR/ime-api/"
+}

--- a/data/indie-ui-events.json
+++ b/data/indie-ui-events.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/indie-ui-events/"
+}

--- a/data/inputdate.json
+++ b/data/inputdate.json
@@ -2,5 +2,5 @@
   "impl": {
     "caniuse": "input-datetime"
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#date-state-typedate"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#date-state-typedate"
 }

--- a/data/inputdevice.json
+++ b/data/inputdevice.json
@@ -1,0 +1,10 @@
+{
+  "editors": "https://wicg.github.io/InputDeviceCapabilities/",
+  "title": "InputDeviceCapabilities",
+  "wgs": [
+    {
+      "label": "Web Platform Incubator Community Group",
+      "url": "https://www.w3.org/community/wicg/"
+    }
+  ]
+}

--- a/data/inputhint.json
+++ b/data/inputhint.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-placeholder"
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#the-placeholder-attribute",
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-placeholder-attribute",
   "feature": "input placeholder attribute"
 }

--- a/data/inputmode.json
+++ b/data/inputmode.json
@@ -2,5 +2,5 @@
   "impl": {
     "caniuse": "input-inputmode"    
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#input-modalities-the-inputmode-attribute"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#input-modalities-the-inputmode-attribute"
 }

--- a/data/inputpattern.json
+++ b/data/inputpattern.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-pattern"
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#the-pattern-attribute",
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute",
   "feature": "Pattern attribute for input fields"
 }

--- a/data/inputtext.json
+++ b/data/inputtext.json
@@ -2,5 +2,5 @@
   "impl": {
     "caniuse": "input-email-tel-url"
   },
-  "TR": "https://www.w3.org/TR/html/sec-forms.html#email-state-typeemail"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#email-state-typeemail"
 }

--- a/data/mobile-wcag.json
+++ b/data/mobile-wcag.json
@@ -1,0 +1,4 @@
+{
+  "title": "Mobile Accessibility: How WCAG 2.0 and Other W3C/WAI Guidelines Apply to Mobile",
+  "editors": "https://w3c.github.io/Mobile-A11y-TF-Note/"
+}

--- a/data/mwbp-wcag.json
+++ b/data/mwbp-wcag.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/mwbp-wcag/"
+}

--- a/data/notifications.json
+++ b/data/notifications.json
@@ -1,0 +1,6 @@
+{
+  "TR": "https://www.w3.org/TR/notifications/",
+  "impl": {
+    "caniuse": "notifications"
+  }
+}

--- a/data/picture.json
+++ b/data/picture.json
@@ -4,6 +4,6 @@
     "chromestatus": 5910974510923776,
     "webkitstatus": "feature-picture-element"
   },
-  "TR": "https://www.w3.org/TR/html/semantics-embedded-content.html#the-picture-element",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-picture-element",
   "feature": "picture element"
 }

--- a/data/speech-api.json
+++ b/data/speech-api.json
@@ -1,0 +1,13 @@
+{
+  "title": "Web Speech API",
+  "editors": "https://dvcs.w3.org/hg/speech-api/raw-file/9a0075d25326/speechapi.html",
+  "wgs": [
+    {
+      "url": "https://www.w3.org/community/speech-api/",
+      "label": "Speech API Community Group"
+    }
+  ],
+  "impl": {
+    "caniuse": "speech-recognition"
+  }
+}

--- a/data/srcset.json
+++ b/data/srcset.json
@@ -2,6 +2,6 @@
   "impl": {
     "chromestatus": 4644337115725824
   },
-  "TR": "https://www.w3.org/TR/html/semantics-embedded-content.html#element-attrdef-img-srcset",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#element-attrdef-img-srcset",
   "feature": "srcset attribute"
 }

--- a/data/timeupdate.json
+++ b/data/timeupdate.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html5/embedded-content-0.html#event-media-timeupdate",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-timeupdate",
   "feature": "timeupdate event"
 }

--- a/data/vibration.json
+++ b/data/vibration.json
@@ -1,0 +1,6 @@
+{
+  "impl": {
+    "caniuse": "vibration"
+  },
+  "TR": "https://www.w3.org/TR/vibration/"
+}

--- a/data/video.json
+++ b/data/video.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html5/embedded-content-0.html#the-video-element",
+  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-video-element",
   "feature": "video element"
 }

--- a/data/wai-aria.json
+++ b/data/wai-aria.json
@@ -1,0 +1,6 @@
+{
+  "TR": "https://www.w3.org/TR/wai-aria/",
+  "impl": {
+    "caniuse": "wai-aria"
+  }
+}

--- a/data/wake-lock.json
+++ b/data/wake-lock.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/wake-lock/"
+}

--- a/mobile/userinput.html
+++ b/mobile/userinput.html
@@ -1,50 +1,67 @@
 <!DOCTYPE html>
 <html lang="en">
+  <head>
     <meta charset="utf-8">
     <title>User Input</title>
+  </head>
+  <body>
     <header>
       <h1>User Input</h1>
     </header>
     <main>
       <section class="featureset well-deployed">
-          <h2>Well-deployed technologies</h2>
-      <div data-feature="Touch-based interactions">
-      <p>An increasing share of mobile devices relies on touch-based interactions. While the traditional interactions recognized in the Web platform (keyboard, mouse input) can still be applied in this context, a more specific handling of touch-based input is a critical aspect of creating well-adapted user experiences, which <strong><a data-featureid="touchevent">Touch Events in the DOM</a></strong> (Document Object Model) enable. The work on that specification is now nearly finished.</p>
-      <p>Meanwhile, the <a href="https://www.w3.org/2012/pointerevents/">Pointer Events Working Group</a> has made good progress on an alternative approach to handle user input, <a data-featureid="pointer-events">Pointer Events</a>, that allows to handle mouse, touch and pen events under a single model. It provides a complementary and more unified  approach to the currently more widely deployed Touch Events.</p>
-      <p>In particular, the <a data-featureid="css-touch-action">CSS property <code>touch-action</code></a> that lets filter gesture events on elements is gaining traction beyond implementations of Pointer Events.</p>
-      <p>The early proposal for an <a data-featureid="inputdevice">InputDevice capabilities API</a> would provide information about a given “mouse” event comes from a touch-capable device.</p>
-      </div>
-      <div data-feature="Smooth scrolling">
-        <p>As more and more content gets rendered as long scrollable lists, more and more logic is attached to scrolling events, and the quality of the user experience of these actions is highly dependent on their performances. The <a data-featureid="smooth-scroll">CSSOM View Module</a> determines when scrolling events get fired, and let developers specify the type of scrolling behavior they want.</p>
-        <p>The proposed work on <a data-featureid="css-snappoints">CSS Scroll Snap Points</a> adds greater ability to control the behavior of panning and scrolling by defining points to which an app view would snap when the user moves through the page.</p>
-      <p>The <a data-featureid="css-will-change">CSS <code>will-change</code></a> property is also available to indicate to browsers that a given part of the page will be soon scrolled to and should be pre-rendered.</p>
-      </div>
-      <p data-feature="On-screen keyboard interactions">Many mobile devices use on-screen keyboards to let users type; the <a data-featureid="ime">Input Method Editor (IME) API</a> makes it possible to coordinate the interactions between that on-screen keyboard and Web applications, but the <a href="https://lists.w3.org/Archives/Public/public-webapps/2015AprJun/0775.html">future of that API is under discussion</a> given its relative lack of adoption.</p>
-      <p data-feature="Vibration">Conversely, many mobile devices use haptic feedback (such as vibration) to create new form of interactions (e.g. in games); work on a <strong><a data-featureid="vibration">vibration API</a></strong> in the <a href="http://www.w3.org/2009/dap/">Device APIs Working Group</a> is making good progress.</p>
-      <p data-feature="Intent-based events">But as the Web reaches new devices, and as devices gain new user interactions mechanisms, it also becomes important to allow Web developers to react to a more abstract set of user interactions: instead of having to work in terms of “click”, “key press”, or “touch event”, being able to react to an “undo” command, or a “next page” command independently of how the user instructed it to the device will prove beneficial to the development of device-independent Web applications. The <a data-featureid="indieui">IndieUI Events</a> specification, developed by the <a href="http://www.w3.org/WAI/IndieUI/">Indie UI Working Group</a>, aims at addressing this need.</p>
-      <p data-feature="Notification">Mobile devices follow their users everywhere, and many mobile users rely on them to remind them or notify them of events, such as messages: the <cite><strong><a data-featureid="notification">Web Notifications</a></strong></cite> specification enables that feature in the Web environment, while the <a data-featureid="push">Push API</a> makes it possible for server-side notifications to alert the user, even if the browser is not running.</p>
-      <p data-feature="Speech-based interactions">Mobile devices, and mobile phones in particular, are also in many cases well-suited to be used through voice-interactions; the <a href="http://www.w3.org/community/speech-api/"><strong>Speech API Community Group</strong></a> is exploring the opportunity of starting standardization work around a <a data-featureid="speechinput">JavaScript API</a> that would make it possible for users to interact with a Web page through spoken commands.</p>
-      <p data-feature="Screen wake">Whether users are speaking commands to their apps or working with them through non-haptic interactions, they risk seeing the screens turned off automatically by their devices screensaver. An early proposal for a <a data-featureid="wake-lock">Wake Lock API</a> would let developers signal the needs to keep the screen up in these circumstances.</p>
+        <h2>Well-deployed technologies</h2>
+        <div data-feature="Touch-based interactions">
+          <p>An increasing share of mobile devices relies on touch-based interactions. While the traditional interactions recognized in the Web platform (keyboard, mouse input) can still be applied in this context, a more specific handling of touch-based input is a critical aspect of creating well-adapted user experiences, which <strong><a data-featureid="touchevent">Touch Events in the DOM</a></strong> (Document Object Model) enable.</p>
+        </div>
 
-      <div data-feature="Accessibility">
-      <p>The hardware constraints of mobile devices, and their different usage context can make <a href="http://www.w3.org/WAI/mobile/experiences">mobile users experience similar barriers to people with disabilities</a>. These similarities in barriers mean that similar solutions can be used to cater for them, <a href="http://www.w3.org/WAI/mobile/overlap">making a Web site accessible both for people with disabilities and mobile devices</a> a natural goal (as detailed in <a data-featureid="mwbp-wcag">Relationship between Mobile Web Best Practices and WCAG</a>).</p>
-      <p>The WCAG and UAWG Working Group provide guidance on mobile accessibility in <a data-featureid="mobile-wcag">how Web Content Accessibility Guidelines (WCAG) and other WAI guidelines apply to mobile</a> — that is, making websites and applications more accessible to people with disabilities when they are using mobile phones and a broad range of other devices</a>.</p>
-      <p><a data-featureid="aria"><cite>WAI-ARIA</cite></a> provides semantic information on widgets, structures and behaviors hooks to make Web applications more accessible, including on mobile devices.</p>
-      </div>
+        <p data-feature="Vibration">The <a data-featureid="vibration">Vibration API</a> lets mobile developers take advantage of haptic feedback to create new form of interactions (e.g. in games).</p>
 
-        </section>
-        <section class="featureset in-progress">
-          <h2>Specifications in progress</h2>
+        <p data-feature="Notification">Mobile devices follow their users everywhere, and many mobile users rely on them to remind them or notify them of events, such as messages: the <a data-featureid="notifications">Web Notifications</a> specification enables that feature in the Web environment.</p>
 
-        </section>
-        <section class="featureset exploratory-work">
-          <h2>Exploratory work</h2>
-                 </section>
-        <section>
-          <h2>Features not covered by ongoing work</h2>
-          
-</section>
-</main>
-        <script src="../js/generate.js"></script>
-    </body>
+        <div data-feature="Accessibility">
+          <p>The hardware constraints of mobile devices, and their different usage context can make <a href="http://www.w3.org/WAI/mobile/experiences">mobile users experience similar barriers to people with disabilities</a>. These similarities in barriers mean that similar solutions can be used to cater for them, <a href="http://www.w3.org/WAI/mobile/overlap">making a Web site accessible both for people with disabilities and mobile devices</a> a natural goal (as detailed in <a data-featureid="mwbp-wcag">Relationship between Mobile Web Best Practices and WCAG</a>).</p>
+          <p>The WCAG and UAWG Working Group provide guidance on mobile accessibility in <a data-featureid="mobile-wcag">how Web Content Accessibility Guidelines (WCAG) and other WAI guidelines apply to mobile</a> — that is, making websites and applications more accessible to people with disabilities when they are using mobile phones and a broad range of other devices</a>.</p>
+          <p><a data-featureid="wai-aria"><cite>WAI-ARIA</cite></a> provides semantic information on widgets, structures and behaviors hooks to make Web applications more accessible, including on mobile devices.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Specifications in progress</h2>
+
+        <div data-feature="Touch-based interactions">
+          <p>The <a href="https://www.w3.org/2012/pointerevents/">Pointer Events Working Group</a> has made good progress on an alternative approach to handle user input, <a data-featureid="pointer-events">Pointer Events</a>, that allows to handle mouse, touch and pen events under a single model. It provides a complementary and more unified  approach to the currently more widely deployed Touch Events.</p>
+          <p>In particular, the <a data-featureid="css-touch-action">CSS property <code>touch-action</code></a> that lets filter gesture events on elements is gaining traction beyond implementations of Pointer Events.</p>
+          <p>The early proposal for an <a data-featureid="inputdevice">InputDevice capabilities API</a> would provide information about a given “mouse” event comes from a touch-capable device.</p>
+        </div>
+
+        <div data-feature="Smooth scrolling">
+          <p>As more and more content gets rendered as long scrollable lists, more and more logic is attached to scrolling events, and the quality of the user experience of these actions is highly dependent on their performances. The <a data-featureid="cssom-view">CSSOM View Module</a> determines when scrolling events get fired, and let developers specify the type of scrolling behavior they want.</p>
+          <p>The proposed work on <a data-featureid="css-scroll-snap">CSS Scroll Snap Points</a> adds greater ability to control the behavior of panning and scrolling by defining points to which an app view would snap when the user moves through the page.</p>
+          <p>The <a data-featureid="css-will-change">CSS <code>will-change</code></a> property is also available to indicate to browsers that a given part of the page will be soon scrolled to and should be pre-rendered.</p>
+        </div>
+
+        <p data-feature="Notification">The <a data-featureid="push">Push API</a> makes it possible for server-side notifications to alert the user, even if the browser is not running.</p>
+
+        <p data-feature="Screen wake">Whether users are speaking commands to their apps or working with them through non-haptic interactions, they risk seeing the screens turned off automatically by their devices screensaver. An early proposal for a <a data-featureid="wake-lock">Wake Lock API</a> would let developers signal the needs to keep the screen up in these circumstances.</p>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+
+        <p data-feature="Speech-based interactions">Mobile devices, and mobile phones in particular, are also in many cases well-suited to be used through voice-interactions; the <a href="https://www.w3.org/community/speech-api/"><strong>Speech API Community Group</strong></a> is exploring the opportunity of starting standardization work around a <a data-featureid="speech-api">JavaScript API</a> that would make it possible for users to interact with a Web page through spoken commands.</p>
+
+        <p data-feature="On-screen keyboard interactions">Many mobile devices use on-screen keyboards to let users type; the <a data-featureid="ime-api">Input Method Editor (IME) API</a> would make it possible to coordinate the interactions between that on-screen keyboard and Web applications. Editorial support is required for this specification to move forward.</p>
+      </section>
+
+      <section>
+        <h2>Discontinued features</h2>
+        <dl>
+          <dt>Intent-based events</dt>
+          <dd>As the Web reaches new devices, and as devices gain new user interactions mechanisms, it seems useful to allow Web developers to react to a more abstract set of user interactions: instead of having to work in terms of “click”, “key press”, or “touch event”, being able to react to an “undo” command, or a “next page” command independently of how the user instructed it to the device. The <a data-featureid="indie-ui-events">IndieUI Events</a> specification was an attempt to address this need. The work has been discontinued for now, due to lack of support from would-be implementers.</dd>
+        </dl>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
 </html>

--- a/specs/impl.json
+++ b/specs/impl.json
@@ -117,6 +117,12 @@
     "indevelopment": [], 
     "shipped": []
   }, 
+  "contacts-sys": {
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": []
+  }, 
   "credential-management": {
     "chromeid": 5026422640869376, 
     "consideration": [
@@ -152,6 +158,12 @@
       "ie", 
       "ie_mob"
     ]
+  }, 
+  "cryptokey": {
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": []
   }, 
   "csp": {
     "chromeid": 4957003285790720, 
@@ -260,11 +272,48 @@
       "android"
     ]
   }, 
+  "css-scroll-snap": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "firefox", 
+      "ios_saf", 
+      "and_ff", 
+      "edge", 
+      "safari", 
+      "ie"
+    ]
+  }, 
   "css-size-adjust": {
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
     "shipped": []
+  }, 
+  "css-touch-action": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "css-transitions": {
     "chromeid": null, 
@@ -478,6 +527,28 @@
     ], 
     "shipped": []
   }, 
+  "html5-download": {
+    "chromeid": 6473924464345088, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android"
+    ]
+  }, 
   "htmlmediaelement": {
     "chromeid": null, 
     "consideration": [], 
@@ -514,11 +585,47 @@
       "chrome"
     ]
   }, 
+  "ime-api": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "edge", 
+      "ie", 
+      "ie_mob"
+    ]
+  }, 
   "inband": {
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
     "shipped": []
+  }, 
+  "indexeddb": {
+    "chromeid": 6507459568992256, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "inputaccept": {
     "consideration": [], 
@@ -527,10 +634,27 @@
     "shipped": []
   }, 
   "inputdate": {
+    "chromeid": null, 
     "consideration": [], 
-    "experimental": [], 
+    "experimental": [
+      "firefox"
+    ], 
     "indevelopment": [], 
-    "shipped": []
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "and_chr", 
+      "android"
+    ]
   }, 
   "inputhint": {
     "chromeid": null, 
@@ -559,8 +683,12 @@
     ]
   }, 
   "inputmode": {
+    "chromeid": null, 
     "consideration": [], 
-    "experimental": [], 
+    "experimental": [
+      "and_ff", 
+      "firefox"
+    ], 
     "indevelopment": [], 
     "shipped": []
   }, 
@@ -590,10 +718,29 @@
     ]
   }, 
   "inputtext": {
+    "chromeid": null, 
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
-    "shipped": []
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "magnetometer": {
     "chromeid": 5698781827825664, 
@@ -726,6 +873,23 @@
       "android"
     ]
   }, 
+  "notifications": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "firefox", 
+      "bb", 
+      "chrome", 
+      "and_ff", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "android"
+    ]
+  }, 
   "orientation": {
     "chromeid": 5698781827825664, 
     "consideration": [], 
@@ -814,6 +978,12 @@
       "op_mob", 
       "and_chr"
     ]
+  }, 
+  "quota": {
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": []
   }, 
   "recording": {
     "chromeid": 5929649028726784, 
@@ -953,6 +1123,22 @@
     "experimental": [], 
     "indevelopment": [], 
     "shipped": []
+  }, 
+  "speech-api": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [
+      "firefox"
+    ], 
+    "indevelopment": [], 
+    "shipped": [
+      "baidu", 
+      "samsung", 
+      "chrome", 
+      "and_qq", 
+      "opera", 
+      "and_chr"
+    ]
   }, 
   "srcset": {
     "chromeid": 4644337115725824, 
@@ -1111,6 +1297,26 @@
     "indevelopment": [], 
     "shipped": []
   }, 
+  "vibration": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "op_mob", 
+      "and_chr", 
+      "android"
+    ]
+  }, 
   "video": {
     "chromeid": null, 
     "consideration": [], 
@@ -1154,6 +1360,30 @@
       "bb", 
       "samsung", 
       "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
+  }, 
+  "wai-aria": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "baidu", 
+      "firefox", 
+      "samsung", 
+      "chrome", 
+      "op_mini", 
       "ios_saf", 
       "and_ff", 
       "and_qq", 
@@ -1288,6 +1518,32 @@
       "ie", 
       "ie_mob"
     ]
+  }, 
+  "websql": {
+    "chromeid": 6330987952734208, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_qq", 
+      "opera", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android"
+    ]
+  }, 
+  "webstorage": {
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": []
   }, 
   "webusb": {
     "chromeid": 5651917954875392, 

--- a/specs/tr.json
+++ b/specs/tr.json
@@ -35,11 +35,11 @@
   }, 
   "audio": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -87,6 +87,15 @@
       }
     ]
   }, 
+  "contacts-sys": {
+    "maturity": "Retired", 
+    "title": "Contacts Manager API", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/2012/sysapps/"
+      }
+    ]
+  }, 
   "credential-management": {
     "maturity": "WD", 
     "title": "Credential Management Level 1", 
@@ -100,6 +109,16 @@
   "crypto": {
     "maturity": "REC", 
     "title": "Web Cryptography API", 
+    "wgs": [
+      {
+        "label": "Web Cryptography Working Group", 
+        "url": "http://www.w3.org/2012/webcrypto/"
+      }
+    ]
+  }, 
+  "cryptokey": {
+    "maturity": "NOTE", 
+    "title": "WebCrypto Key Discovery", 
     "wgs": [
       {
         "label": "Web Cryptography Working Group", 
@@ -185,6 +204,26 @@
       }
     ]
   }, 
+  "css-scroll-snap": {
+    "maturity": "CR", 
+    "title": "CSS Scroll Snap Module Level 1", 
+    "wgs": [
+      {
+        "label": "Cascading Style Sheets (CSS) Working Group", 
+        "url": "http://www.w3.org/Style/CSS/members"
+      }
+    ]
+  }, 
+  "css-touch-action": {
+    "maturity": "WD", 
+    "title": "Pointer Events - Level 2", 
+    "wgs": [
+      {
+        "label": "Pointer Events Working Group", 
+        "url": "http://www.w3.org/2012/pointerevents/"
+      }
+    ]
+  }, 
   "css-transitions": {
     "maturity": "WD", 
     "title": "CSS Transitions", 
@@ -205,13 +244,23 @@
       }
     ]
   }, 
-  "datalist": {
-    "maturity": "REC", 
-    "title": "HTML5", 
+  "cssom-view": {
+    "maturity": "WD", 
+    "title": "CSSOM View Module", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Cascading Style Sheets (CSS) Working Group", 
+        "url": "http://www.w3.org/Style/CSS/members"
+      }
+    ]
+  }, 
+  "datalist": {
+    "maturity": "REC", 
+    "title": "HTML 5.1", 
+    "wgs": [
+      {
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -335,13 +384,23 @@
       }
     ]
   }, 
-  "htmlmediaelement": {
+  "html5-download": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
+      }
+    ]
+  }, 
+  "htmlmediaelement": {
+    "maturity": "REC", 
+    "title": "HTML 5.1", 
+    "wgs": [
+      {
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -359,6 +418,34 @@
       }
     ]
   }, 
+  "ime-api": {
+    "maturity": "Retired", 
+    "title": "Input Method Editor API", 
+    "wgs": [
+      {
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
+      }
+    ]
+  }, 
+  "indexeddb": {
+    "maturity": "REC", 
+    "title": "Indexed Database API", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/2008/webapps/"
+      }
+    ]
+  }, 
+  "indie-ui-events": {
+    "maturity": "WD", 
+    "title": "IndieUI: Events 1.0", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/WAI/IndieUI/"
+      }
+    ]
+  }, 
   "inputaccept": {
     "maturity": "CR", 
     "title": "HTML Media Capture", 
@@ -371,21 +458,21 @@
   }, 
   "inputdate": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
   "inputhint": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -401,21 +488,21 @@
   }, 
   "inputpattern": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
   "inputtext": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -489,6 +576,29 @@
       }
     ]
   }, 
+  "mwbp-wcag": {
+    "maturity": "NOTE", 
+    "title": "Relationship between Mobile Web Best Practices (MWBP) and Web Content Accessibility Guidelines (WCAG)", 
+    "wgs": [
+      {
+        "label": "Mobile Web Best Practices Working Group", 
+        "url": "http://www.w3.org/2005/MWI/BPWG/"
+      }, 
+      {
+        "label": "Education and Outreach Working Group", 
+        "url": "http://www.w3.org/WAI/EO/"
+      }
+    ]
+  }, 
+  "notifications": {
+    "maturity": "REC", 
+    "title": "Web Notifications", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/2010/web-notifications/"
+      }
+    ]
+  }, 
   "orientation": {
     "maturity": "WD", 
     "title": "Orientation Sensor", 
@@ -510,8 +620,8 @@
     ]
   }, 
   "picture": {
-    "maturity": "CR", 
-    "title": "HTML 5.2", 
+    "maturity": "REC", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
         "label": "Web Platform Working Group", 
@@ -532,6 +642,16 @@
   "push": {
     "maturity": "WD", 
     "title": "Push API", 
+    "wgs": [
+      {
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
+      }
+    ]
+  }, 
+  "quota": {
+    "maturity": "Retired", 
+    "title": "Quota Management API", 
     "wgs": [
       {
         "label": "Web Platform Working Group", 
@@ -638,8 +758,8 @@
     ]
   }, 
   "srcset": {
-    "maturity": "CR", 
-    "title": "HTML 5.2", 
+    "maturity": "REC", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
         "label": "Web Platform Working Group", 
@@ -679,11 +799,11 @@
   }, 
   "timeupdate": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "HTML 5.1", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -757,13 +877,23 @@
       }
     ]
   }, 
-  "video": {
+  "vibration": {
     "maturity": "REC", 
-    "title": "HTML5", 
+    "title": "Vibration API", 
     "wgs": [
       {
-        "label": "HTML Media Extensions Working Group", 
-        "url": "http://www.w3.org/html/wg/"
+        "label": "Device and Sensors Working Group", 
+        "url": "http://www.w3.org/2009/dap/"
+      }
+    ]
+  }, 
+  "video": {
+    "maturity": "REC", 
+    "title": "HTML 5.1", 
+    "wgs": [
+      {
+        "label": "Web Platform Working Group", 
+        "url": "http://www.w3.org/WebPlatform/WG/"
       }
     ]
   }, 
@@ -774,6 +904,25 @@
       {
         "label": "Cascading Style Sheets (CSS) Working Group", 
         "url": "http://www.w3.org/Style/CSS/members"
+      }
+    ]
+  }, 
+  "wai-aria": {
+    "maturity": "REC", 
+    "title": "Accessible Rich Internet Applications (WAI-ARIA) 1.0", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/WAI/PF/"
+      }
+    ]
+  }, 
+  "wake-lock": {
+    "maturity": "WD", 
+    "title": "Wake Lock API", 
+    "wgs": [
+      {
+        "label": "Device and Sensors Working Group", 
+        "url": "http://www.w3.org/2009/dap/"
       }
     ]
   }, 
@@ -834,6 +983,24 @@
   "websockets": {
     "maturity": "CR", 
     "title": "The WebSocket API", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/2008/webapps/"
+      }
+    ]
+  }, 
+  "websql": {
+    "maturity": "Retired", 
+    "title": "Web SQL Database", 
+    "wgs": [
+      {
+        "url": "http://www.w3.org/2008/webapps/"
+      }
+    ]
+  }, 
+  "webstorage": {
+    "maturity": "REC", 
+    "title": "Web Storage", 
     "wgs": [
       {
         "url": "http://www.w3.org/2008/webapps/"


### PR DESCRIPTION
The update also fixes data URLs to use "real" shortnames instead of aliases that redirect to some real shortname (e.g. "html51" instead of "html").