### PR TITLE
Replace Quota Management API by Storage spec

### DIFF
--- a/data/storage.json
+++ b/data/storage.json
@@ -1,0 +1,13 @@
+{
+  "title": "Storage",
+  "ls": "https://storage.spec.whatwg.org/",
+  "wgs": [
+    {
+      "label": "WHATWG",
+      "url": "https://whatwg.org/"
+    }
+  ],
+  "impl": {
+    "chromestatus": 5630353511284736
+  }
+}

--- a/mobile/storage.html
+++ b/mobile/storage.html
@@ -31,12 +31,15 @@
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
 
-        <p data-feature="Quota for storage">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space, which the proposed <a data-featureid="quota">Quota Management API</a> will offer to Web applications.</p>
+        <p data-feature="Quota for storage">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space. The proposed <a data-featureid="storage">Storage</a> specification will allow Web applications to get quota estimate for storage as well as to request that the data stored by the application be treated as persistent and cannot be evicted without the user’s explicit consent.</p>
       </section>
 
       <section>
         <h2>Discontinued features</h2>
         <dl>
+          <dt>Quota management API</dt>
+          <dd>Work on the <a data-featureid="quota">Quota Management API</a>, started in the Web Platform Working Group to expose an API to manage usage and availability of local storage resources, was discontinued in favor of the newer <a data-featureid="storage">Storage</a> proposal.</dd>
+
           <dt>Client-side SQL-based database</dt>
           <dd>The work around a <a data-featureid="websql">client-side SQL-based database</a>, which had been started in 2009, has been abandoned in favor of the work on IndexedDB.</dd>
 


### PR DESCRIPTION
The Quota Management API has been discontinued in favor of the Storage spec.