### PR TITLE
[mobile] Second pass on the Graphics section

### DIFF
--- a/data/css-2d.json
+++ b/data/css-2d.json
@@ -1,4 +1,7 @@
 {
-  "impl": {},
-  "TR": "https://www.w3.org/TR/css-transforms-1/"
+  "TR": "https://www.w3.org/TR/css-transforms-1/",
+  "feature": "2D effects",
+  "impl": {
+    "caniuse": "transforms2d"
+  }
 }

--- a/data/css-3d.json
+++ b/data/css-3d.json
@@ -1,4 +1,7 @@
 {
-  "impl": {},
-  "TR": "https://www.w3.org/TR/css-transforms-1/"
+  "TR": "https://www.w3.org/TR/css-transforms-1/",
+  "feature": "3D effects",
+  "impl": {
+    "caniuse": "transforms3d"
+  }
 }

--- a/data/css-border-background.json
+++ b/data/css-border-background.json
@@ -1,0 +1,7 @@
+{
+  "TR": "https://www.w3.org/TR/css3-background/",
+  "feature": "Complex backgrounds",
+  "impl": {
+    "caniuse": "border-radius"
+  }
+}

--- a/data/css-border-radius.json
+++ b/data/css-border-radius.json
@@ -1,0 +1,7 @@
+{
+  "TR": "https://www.w3.org/TR/css3-background/",
+  "feature": "Rounded corners",
+  "impl": {
+    "caniuse": "border-radius"
+  }
+}

--- a/data/css-border-shadow.json
+++ b/data/css-border-shadow.json
@@ -1,0 +1,7 @@
+{
+  "TR": "https://www.w3.org/TR/css3-background/",
+  "feature": "Box shadow effects",
+  "impl": {
+    "caniuse": "css-boxshadow"
+  }
+}

--- a/data/css-border.json
+++ b/data/css-border.json
@@ -1,4 +1,0 @@
-{
-  "impl": {},
-  "TR": "https://www.w3.org/TR/css3-background/"
-}

--- a/mobile/graphics.html
+++ b/mobile/graphics.html
@@ -1,48 +1,49 @@
 <!DOCTYPE html>
 <html lang="en">
-<meta charset="utf-8">
-<title>Graphics and Layout</title>
-<header>
-    <h1>Graphics and Layout</h1>
-</header>
-<main>
-
-    <section class="featureset well-deployed">
+  <head>
+    <meta charset="utf-8">
+    <title>Graphics and Layout</title>
+  </head>
+  <body>
+    <header>
+      <h1>Graphics and Layout</h1>
+      <p></p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
         <h2>Well-deployed technologies</h2>
 
-        <div data-feature="2D Vector Graphics">
-            <p><strong><a data-featureid="svg12">SVG</a></strong>, Scalable Vector Graphics, provides an XML-based markup language to describe two-dimensions vector graphics. Since these graphics are described as a set of geometric shapes, they can be zoomed at the user request, which makes them well-suited to create graphics on mobile devices where screen space is limited. They can also be easily animated, enabling the creation of very advanced and slick user interfaces.</p>
-            <p>The integration of SVG in HTML5 opens up new possibilities, for instance applying advanced graphic filters (through SVG filters) to multimedia content, including videos. <a data-featureid="svg2">SVG 2</a> is set to facilitate that integration and complete the set of features in SVG.</p>
+        <p>Content on the Web can be styled using <strong><a href="https://www.w3.org/standards/techs/css">CSS</a></strong> (Cascading Style Sheets); in particular, CSS3 (the third level of the specification) is built as a collection of specifications that define simple yet powerful features to create graphical effects, such as <span data-feature="Borders and background Effects"><a data-featureid="css-border-radius">rounded corners</a>, <a data-featureid="css-border-background">complex background images</a>, <a data-featureid="css-border-shadow">shadow effects</a></span>, <span data-feature="Transformation Effects"><a data-featureid="css-2d">rotated content</a> (<a href="http://www.w3.org/TR/css3-transforms/">CSS Transforms</a>, which also includes <a data-featureid="css-3d">3D effects</a>)</span>.</p>
+        <div data-feature="Animations">
+          <p>Animations can be described declaratively via <a data-featureid="css-animation">CSS Animations</a> and <a data-featureid="css-transitions">CSS Transitions</a>.</p>
+          <p>Scripted animations can be resource intensive, especially on constrained devices. The possibility offered by the <a data-featureid="animation-frames">Animation Frames</a> to manage the rate of updates to animations can help to keep them under control.</p>
         </div>
-
-        <p data-feature="2D Programmatic API">In complement to the declarative approach provided by SVG, the <strong><code>&lt;canvas&gt;</code></strong> element added in HTML5 enables a <a data-featureid="canvas">2D programmatic API</a> that is well-suited for processing graphics in a less memory intensive way.</p>
-
-        <p>Both SVG and HTML can be styled using <strong><a href="https://www.w3.org/standards/techs/css">CSS</a></strong> (Cascading Style Sheets); in particular, CSS3 (the third level of the specification) is built as a collection of specifications set to offer a large number of new features that make it simple to create graphical effects, such as <a data-featureid="css-border" data-feature="Rounded Corners">rounded corners</a>, <a data-featureid="css-border" data-feature="Complex background images">complex background images</a>, <a data-feature="Box shadow effects" data-featureid="css-border">shadow effects</a> , <a data-feature="2D Effects" data-featureid="css-2d">rotated content</a> (<a href="http://www.w3.org/TR/css3-transforms/">CSS Transforms</a>, including with <a data-feature="3D Effects" data-featureid="css-3d">3D effects</a>).</p>
-        <p data-feature="Complex layouts"><a data-featureid="flexbox">CSS Flexbox</a> allows to build complex layouts as required for interactive applications on small screens.</p>
+        <p data-feature="Complex layouts"><a data-featureid="flexbox">CSS Flexbox</a> introduces a new layout mode, designed for laying out more complex applications. Notably, CSS Flexbox makes it possible to preserve a clear separation between the content itself (HTML, SVG) and its layout by allowing re-ordering of elements on screen, without having to change the underlying HTML. This is particularly relevant on mobile devices where the user interface and user experience need to be adjusted to fit the screen and available interaction mechanisms (see also <a href="adaptation.html">Device Adaptation</a>).</p>
         <div data-feature="Downloadable fonts">
-            <p>Fonts play also an important role in building appealing graphical interfaces, but mobile devices are in general distributed with only a limited set of fonts. <strong><a data-featureid="woff">WOFF 1.0</a></strong> (Web Open Font Format) addresses that limitation by making it easy to use fonts that are automatically downloaded through style sheets, while keeping the size of the downloaded fonts limited to what is actually needed to render the interface. The upcoming <a data-featureid="woff2">WOFF 2.0</a> update to that format promises 25%-smaller download sizes; on mobile, a 35% reduction in the time needed to download and display these fonts has been measured.</p>
+          <p>Fonts play also an important role in building appealing graphical interfaces, but mobile devices are in general distributed with only a limited set of fonts. <strong><a data-featureid="woff">WOFF 1.0</a></strong> (Web Open Font Format) addresses that limitation by making it easy to use fonts that are automatically downloaded through style sheets, while keeping the size of the downloaded fonts limited to what is actually needed to render the interface. The upcoming <a data-featureid="woff2">WOFF 2.0</a> update to that format promises 25%-smaller download sizes; on mobile, a 35% reduction in the time needed to download and display these fonts has been measured.</p>
         </div>
-        <p>Another important aspect in graphics-intensive applications (e.g. games) is the possibility to use the entire screen to display the said graphics; the work on a <strong><a href="https://fullscreen.spec.whatwg.org/">Fullscreen API</a></strong>  to request and detect full screen display, previously co-developed by the Web Applications and CSS Working Groups, has now fully moved to the <a href="https://whatwg.org/">WHATWG</a>.</p>
-        <p>NB: a <a href="http://www.khronos.org/webgl/">3D graphic API for HTML5 <code>canvas</code>, called WebGL</a>, has been developed outside of W3C, as part of the <a href="http://www.khronos.org/">Khronos Group</a>; this API has been built to be compatible with <a href="http://www.khronos.org/opengles/">OpenGL ES</a>, i.e. for embedded systems, and is intended to work on mobile devices.</p>
-
-    </section>
-    <section class="featureset in-progress">
+        <div data-feature="2D Vector Graphics">
+          <p><strong><a data-featureid="svg12">SVG</a></strong>, Scalable Vector Graphics, provides an XML-based markup language to describe two-dimensions vector graphics. Since these graphics are described as a set of geometric shapes, they can be zoomed at the user request, which makes them well-suited to create graphics on mobile devices where screen space is limited. They can also be easily animated, enabling the creation of very advanced and slick user interfaces.</p>
+          <p>The integration of SVG in HTML5 opens up new possibilities, for instance applying advanced graphic filters (through SVG filters) to multimedia content, including videos. <a data-featureid="svg2">SVG 2</a> is set to facilitate that integration and complete the set of features in SVG.</p>
+        </div>
+        <p data-feature="2D Programmatic API">In complement to the declarative approach provided by SVG, the <strong><code>&lt;canvas&gt;</code></strong> element added in HTML5 enables a <a data-featureid="canvas">2D programmatic API</a> that is well-suited for processing graphics in a less memory intensive way.</p>
+        <p>Another important aspect in graphics-intensive applications (e.g. games) is the possibility to use the entire screen to display the said graphics; the work on a <strong><a href="https://fullscreen.spec.whatwg.org/">Fullscreen API</a></strong>  to request and detect full screen display, now done in the <a href="https://whatwg.org/">WHATWG</a>.</p>
+        <p><strong>NB:</strong> a <a href="http://www.khronos.org/webgl/">3D graphic API for HTML5 <code>canvas</code>, called WebGL</a>, has been developed outside of W3C, as part of the <a href="http://www.khronos.org/">Khronos Group</a>; this API has been built to be compatible with <a href="http://www.khronos.org/opengles/">OpenGL ES</a>, i.e. for embedded systems, and is intended to work on mobile devices. The <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a> also started to design a new Web API to expose modern 3D graphics and computation capabilities in a performant, powerful and safe manner, with a goal to be agnostic of and compatible with existing native system platforms (such as Direct3D, Metal, or Vulkan).</p>
+      </section>
+      <section class="featureset in-progress">
         <h2>Specifications in progress</h2>
         <div data-feature="Animations">
-            <p>Animations can be described declaratively via <a data-featureid="css-animation">CSS Animations</a>, and <a data-featureid="css-transitions">CSS Transitions</a>.</p>
-            <p>Animations can also be managed via scripting through the API exposed in <a data-featureid="webanimations">Web Animations</a>; as they can be resource intensive, the possibility offered by the <a data-featureid="animation-frames">Animation Frames</a> to manage the rate of updates to animations can help keep them under control.</p>
-            <p>To ensure optimal performances when animating parts of an app, authors can make use of the <a data-featureid="css-will-change">CSS <code>will-change</code></a> property to let browsers compute the animation ahead of its occurrence.</p>
+          <p>Animations can also be managed via scripting through the API exposed in <a data-featureid="webanimations">Web Animations</a>.</p>
+          <p>To ensure optimal performances when animating parts of an app, authors can make use of the <a data-featureid="css-will-change">CSS <code>will-change</code></a> property to let browsers compute the animation ahead of its occurrence.</p>
         </div>
 
         <div data-feature="Downloadable fonts">
-            <p>Given the time required for downloading fonts over mobile networks, authors need to adapt their content to the progressive availability of fonts; <a data-featureid="css-font-loading">CSS Font Loading</a> gives the necessary events to developers to enable that adaptation.</p>
+          <p>Given the time required for downloading fonts over mobile networks, authors need to adapt their content to the progressive availability of fonts; <a data-featureid="css-font-loading">CSS Font Loading</a> gives the necessary events to developers to enable that adaptation.</p>
         </div>
 
         <p data-feature="Orientation Lock">It is often useful to be able to <strong>lock the orientation of the screen</strong>; the <a data-featureid="screenlock">Screen Orientation API</a> allows not only to detect orientation change, but also to lock the orientation in a specific state.</p>
-
-    </section>
-</main>
-<script src="../js/generate.js"></script>
-</body>
-
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
 </html>

--- a/specs/impl.json
+++ b/specs/impl.json
@@ -332,16 +332,54 @@
     ]
   }, 
   "css-2d": {
+    "chromeid": null, 
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
-    "shipped": []
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "css-3d": {
+    "chromeid": null, 
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
-    "shipped": []
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "css-animation": {
     "chromeid": null, 
@@ -368,11 +406,80 @@
       "ie_mob"
     ]
   }, 
-  "css-border": {
+  "css-border-background": {
+    "chromeid": null, 
     "consideration": [], 
     "experimental": [], 
     "indevelopment": [], 
-    "shipped": []
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
+  }, 
+  "css-border-radius": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
+  }, 
+  "css-border-shadow": {
+    "chromeid": null, 
+    "consideration": [], 
+    "experimental": [], 
+    "indevelopment": [], 
+    "shipped": [
+      "and_uc", 
+      "baidu", 
+      "firefox", 
+      "bb", 
+      "samsung", 
+      "chrome", 
+      "ios_saf", 
+      "and_ff", 
+      "and_qq", 
+      "opera", 
+      "edge", 
+      "op_mob", 
+      "safari", 
+      "and_chr", 
+      "android", 
+      "ie", 
+      "ie_mob"
+    ]
   }, 
   "css-color-space": {
     "consideration": [], 

--- a/specs/tr.json
+++ b/specs/tr.json
@@ -237,7 +237,27 @@
       }
     ]
   }, 
-  "css-border": {
+  "css-border-background": {
+    "maturity": "CR", 
+    "title": "CSS Backgrounds and Borders Module Level 3", 
+    "wgs": [
+      {
+        "label": "Cascading Style Sheets (CSS) Working Group", 
+        "url": "http://www.w3.org/Style/CSS/members"
+      }
+    ]
+  }, 
+  "css-border-radius": {
+    "maturity": "CR", 
+    "title": "CSS Backgrounds and Borders Module Level 3", 
+    "wgs": [
+      {
+        "label": "Cascading Style Sheets (CSS) Working Group", 
+        "url": "http://www.w3.org/Style/CSS/members"
+      }
+    ]
+  }, 
+  "css-border-shadow": {
     "maturity": "CR", 
     "title": "CSS Backgrounds and Borders Module Level 3", 
     "wgs": [


### PR DESCRIPTION
Main changes:
- start section with CSS, since that's the core technology here
- adjusted references to CSS Borders and Background specs
- added references to Can I Use for some of the missing specs (probably need to be completed with IDs from other platform status sites, not done for now)
- moved requestAnimationFrame, CSS Flexbox, CSS Animations and CSS Transitions to well-deployed section
- re-indented content