### PR TITLE
[mobile] Second pass at Forms section

### DIFF
--- a/data/inputdate.json
+++ b/data/inputdate.json
@@ -2,5 +2,6 @@
   "impl": {
     "caniuse": "input-datetime"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#date-state-typedate"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#date-state-typedate",
+  "feature": "Date and time input types"
 }

--- a/data/inputmode.json
+++ b/data/inputmode.json
@@ -2,5 +2,6 @@
   "impl": {
     "caniuse": "input-inputmode"    
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#input-modalities-the-inputmode-attribute"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#input-modalities-the-inputmode-attribute",
+  "feature": "inputmode attribute"
 }

--- a/data/inputtext.json
+++ b/data/inputtext.json
@@ -2,5 +2,6 @@
   "impl": {
     "caniuse": "input-email-tel-url"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#email-state-typeemail"
+  "TR": "https://www.w3.org/TR/html51/sec-forms.html#email-state-typeemail",
+  "feature": "tel, email, url input types"
 }

--- a/mobile/forms.html
+++ b/mobile/forms.html
@@ -21,7 +21,14 @@
       <section class="featureset in-progress">
         <h2>Specifications in progress</h2>
         <p data-feature="Customized text entries"><a data-featureid="inputdate">Date and time entries</a> can take advantage of a number of dedicated form controls (e.g. <code>&lt;input type="date"&gt;</code>) to trigger the use of a native calendar control, avoiding the need to create custom JS-based controls that cannot be easily tailored to cope for the variety of mobile devices available on the market.</p>
-        <p data-feature="Input modality">the <code><a data-featureid="inputmode">inputmode</a></code> attribute defines the type of textual input expected in a text entry. Mobile browsers may use that hint to render the right type of on-screen keyboard, for instance a keypad when the user is expected to enter a number. This attribute may be removed from future versions of HTML due to lack of implementations though.</p>
+      </section>
+
+      <section>
+        <h2>Discontinued features</h2>
+        <dl>
+          <dt>Input modality</dt>
+          <dd>The <code><a data-featureid="inputmode">inputmode</a></code> attribute defined the type of textual input expected in a text entry. Mobile browsers could use that hint to render the right type of on-screen keyboard, for instance to display a keypad when the user was expected to enter a credit card number. This attribute is no longer supported in recent browsers and has been removed from HTML. Developers are encouraged to use more specific input types (such as <code>tel</code>, <code>email</code> and <code>url</code>).</dd>
+        </dl>
       </section>
     </main>
     <script src="../js/generate.js"></script>

--- a/mobile/forms.html
+++ b/mobile/forms.html
@@ -4,38 +4,26 @@
     <title>Forms</title>
     <header>
       <h1>Forms</h1>
-      <p>The ability to build rich forms with HTML is the basis for user input in most Web-based applications.</p>
+      <p>The ability to build rich forms with HTML is the basis for user input in most Web-based applications. Due to the absence of physical keyboards and the limited size available for on-screen keyboards, text input on mobile devices remains a difficult task for most users though. HTML defines new types of form controls that optimize the way users may enter data.</p>
     </header>
     <main>
-
       <section class="featureset well-deployed">
-          <h2>Well-deployed technologies</h2>
-      <p>The ability to build rich forms with HTML is the basis for user input in most Web-based applications. Due to their limited keyboards, text input on mobile devices remains a difficult task for most users; HTML5 address parts of this problem by offering new type of form controls that optimize the way users will enter data:</p>
-      <ul>
-<li data-feature="Date and time entries"><strong><a data-featureid="inputdate">date and time entries</a></strong> can take advantage of a number of dedicated form controls (e.g. <code>&lt;input type="date"&gt;</code>) where the user can use a native calendar control;</li>
-<li data-feature="Customized text entries (tel, email, url)">the <code><a data-featureid="inputtext">&lt;input type="<strong>email</strong>"&gt;</a></code>, <code><a href="https://www.w3.org/TR/html/sec-forms.html#telephone-state-typetel">&lt;input type="<strong>tel</strong>"&gt;</a></code> and <code><a href="https://www.w3.org/TR/html/sec-forms.html#url-state-typeurl">&lt;input type="<strong>url</strong>"&gt;</a></code> can be used to optimize the ways user enter these often-difficult to type data, e.g. through dedicated virtual keyboards, or by accessing on-device records for these data (from the address book, bookmarks, etc.);</li>
-<li data-feature="Input modality">the <code><a data-featureid="inputmode"><strong>inputmode</strong></a></code> attribute defines the type of textual input expected in a text entry;</li>
-<li data-feature="Input pattern">the <code><a data-featureid="inputpattern"><strong>pattern</strong></a></code> attribute allows both to guide user input as well as to avoid server-side validation (which requires a network round-trip) or JavaScript-based validation (which takes up more resources);</li>
-<li data-feature="Input hint">the <code><strong><a data-featureid="inputhint">placeholder</a></strong></code> attribute allows to guide user input by inserting hints as to what type of content is expected in a text-entry control;</li>
-<li data-feature="Autocomplete for text entries">the <code><a data-featureid="datalist">&lt;datalist&gt;</a></code> element allows creating free-text input controls coming with <strong>pre-defined values</strong> the user can select from; the <a data-featureid="autocomplete"><code>autocomplete</code> attribute</a> is a mechanism to automatically fill input fields based on <strong>well-known data</strong> for the user.</li>
-</ul>
-        </section>
+        <h2>Well-deployed technologies</h2>
+        <p data-feature="Customized text entries">The <code><a data-featureid="inputtext">&lt;input type="<strong>email</strong>"&gt;</a></code>, <code><a href="https://www.w3.org/TR/html51/sec-forms.html#telephone-state-typetel">&lt;input type="<strong>tel</strong>"&gt;</a></code> and <code><a href="https://www.w3.org/TR/html51/sec-forms.html#url-state-typeurl">&lt;input type="<strong>url</strong>"&gt;</a></code> can be used to optimize the ways user enter these often-difficult to type data, e.g. through dedicated virtual keyboards, or by accessing on-device records for these data (from the address book, bookmarks, etc.).</p>
 
-        <!-- <section class="featureset in-progress">
-          <h2>Specifications in progress</h2>
+        <p data-feature="Input validation">The <code><a data-featureid="inputpattern">pattern</a></code> attribute allows both to guide user input as well as to avoid server-side validation (which requires a network round-trip) or JavaScript-based validation (which takes up more resources), both useful optimization on constrained mobile devices.</p>
 
-        </section>
+        <p data-feature="Input hint">The <code><a data-featureid="inputhint">placeholder</a></code> attribute allows to guide user input by inserting hints that describe the type of content expected in a text-entry control.</p>
 
-        <section class="featureset exploratory-work">
-          <h2>Exploratory work</h2>
+        <p data-feature="Form autocomplete">The <code><a data-featureid="datalist">&lt;datalist&gt;</a></code> element allows creating free-text input controls coming with <strong>pre-defined values</strong> the user can select from; the <a data-featureid="autocomplete"><code>autocomplete</code> attribute</a> is a mechanism to automatically fill input fields based on <strong>well-known data</strong> for the user, solving the problem of working with long and multi-page forms that are common on mobile devices, e.g. in mobile purchase scenarios.</li>
+      </section>
 
-        </section>
-
-        <section>
-          <h2>Features not covered by ongoing work</h2>
-</section> -->
-
-</main>
-        <script src="../js/generate.js"></script>
-    </body>
+      <section class="featureset in-progress">
+        <h2>Specifications in progress</h2>
+        <p data-feature="Customized text entries"><a data-featureid="inputdate">Date and time entries</a> can take advantage of a number of dedicated form controls (e.g. <code>&lt;input type="date"&gt;</code>) to trigger the use of a native calendar control, avoiding the need to create custom JS-based controls that cannot be easily tailored to cope for the variety of mobile devices available on the market.</p>
+        <p data-feature="Input modality">the <code><a data-featureid="inputmode">inputmode</a></code> attribute defines the type of textual input expected in a text entry. Mobile browsers may use that hint to render the right type of on-screen keyboard, for instance a keypad when the user is expected to enter a number. This attribute may be removed from future versions of HTML due to lack of implementations though.</p>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
 </html>


### PR DESCRIPTION
Main changes:
- moved date and time input types and inputmode attribute to "in progress" section given the lack of implementation support for now.
- noted the uncertain future of the "inputmode" attribute, which may be removed from HTML due to lack of implementations
- renamed features as needed
- removed use of bold around feature names
- re-indented content