### PR TITLE
Unify the title of the publishing roadmap

### DIFF
--- a/publishing/index.html
+++ b/publishing/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
 <head>
     <meta charset="utf-8">
-    <title>W3C Technologies for Web Publications</title>
+    <title>Roadmap of Technologies Needed for Web Publications</title>
 </head>
 <body>
     <header>
-        <h1>Roadmap of Web Applications on Mobile</h1>
+        <h1>Roadmap of Technologies Needed for Web Publications</h1>
         <p>
             One of the goals of the <a href="https://www.w3.org/publishing/groups/publ-wg/">Publishing Working groups</a> is to rely, as much as possible, on technologies developed elsewhere at W3C, so that the Web Publication specific technologies would become a minimal layer on the top of the existing Web, rather then giving the impression of forking it. These pages collect references to those W3C technologies that already exist, or are under development, and could provide the foundation of the that work.
         </p>


### PR DESCRIPTION
Stolen from `toc.json`.