### PR TITLE
Generate IDs, auto-expand feature names, preserve custom directives

### DIFF
--- a/js/generate-index.js
+++ b/js/generate-index.js
@@ -1,8 +1,6 @@
 const $ = (el, selector) =>
   Array.prototype.slice.call(el.querySelectorAll(selector), 0);
 
-const hero = $(document, 'header > *').map(el => el.cloneNode(true));
-
 const scripts = ['../js/sidenav.js'];
 
 const templateItem = '<a href=""><div class="icon"><img src="" width="45" alt=""></div><div class="description"><h2></h2><p></p></div></a>';
@@ -12,7 +10,16 @@ let templateXhr = new XMLHttpRequest();
 templateXhr.responseType = 'text';
 templateXhr.open('GET', '../js/template-index');
 templateXhr.onload = function() {
+  // Save useful content from initial document
+  // (custom elements in the head, main header)
+  const headElements = $(document, 'head > *').filter(el =>
+    (el.nodeName !== 'TITLE') &&
+    !((el.nodeName === 'META') && el.getAttribute('charset')));
+  const hero = $(document, 'header > *');
+
+  // Replace doc by template doc and complete with content saved above
   document.documentElement.innerHTML = this.responseText;
+  headElements.forEach(el => document.querySelector('head').appendChild(el));
   hero.forEach(el => document.querySelector('.hero .container').appendChild(el));
 
   let tocXhr = new XMLHttpRequest();

--- a/js/generate-index.js
+++ b/js/generate-index.js
@@ -10,8 +10,8 @@ let templateXhr = new XMLHttpRequest();
 templateXhr.responseType = 'text';
 templateXhr.open('GET', '../js/template-index');
 templateXhr.onload = function() {
-  // Save useful content from initial document
-  // (custom elements in the head, main header)
+  // Preserve initial content that needs to appear in final document
+  // (head elements, main header)
   const headElements = $(document, 'head > *').filter(el =>
     (el.nodeName !== 'TITLE') &&
     !((el.nodeName === 'META') && el.getAttribute('charset')));

--- a/js/generate.js
+++ b/js/generate.js
@@ -146,8 +146,8 @@ let templateXhr = new XMLHttpRequest();
 templateXhr.responseType = 'text';
 templateXhr.open('GET', '../js/template-page');
 templateXhr.onload = function() {
-  // Save useful content from initial document
-  // (custom elements in the head, main header and sections)
+  // Preserve initial content that needs to appear in final document
+  // (head elements, main header and sections)
   const headElements = $(document, 'head > *').filter(el =>
     (el.nodeName !== 'TITLE') &&
     !((el.nodeName === 'META') && el.getAttribute('charset')));


### PR DESCRIPTION
This commit implements the following changes:
- Custom directives in the <head> are now preserved. This makes it possible to set a different <base> but also to override the CSS as well as to insert JS code if needed (fixes #76)
- Given an empty <a data-featureid="[feature]"></a>, the code automatically sets the content of the link to the name of the feature if it exists, in other words the "feature" value in the "data/[feature].json" file, or to the title of the underlying specification otherwise (fixes #78)
- IDs are automatically generated for sections, feature paragraphs and individual feature references. The code used was stolen from Respec (fixes #95)