### PR TITLE
[mobile] Add Geolocation Sensor

### DIFF
--- a/data/geolocation-sensor.json
+++ b/data/geolocation-sensor.json
@@ -1,0 +1,10 @@
+{
+    "title": "Geolocation Sensor",
+    "wgs": [
+        {
+            "url": "https://www.w3.org/community/wicg/",
+            "label": "Web Platform Incubator Community Group"
+        }
+    ],
+    "editors": "https://wicg.github.io/geolocation-sensor/"
+}

--- a/mobile/sensors.html
+++ b/mobile/sensors.html
@@ -42,6 +42,8 @@
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
 
+        <p data-feature="Geolocation">The <a data-featureid="geolocation-sensor">Geolocation Sensor</a> is an API for obtaining geolocation reading from the hosting device. The feature set of the Geolocation Sensor is similar to that of the Geolocation API, but it is surfaced through the Generic Sensor API, improves security and privacy, and is extensible.</p>
+
         <p data-feature="Camera &amp; Microphone streams">As detailed in the <a href="media.html">Media</a> part of this document, there is ongoing work on <a data-featureid="getusermedia">APIs to open up access to camera and microphone</a> streams.</p>
 
         <p data-feature="NFC">Work on a <a href="http://w3c.github.io/web-nfc/" data-featureid="webnfc">Web Near-Field Communications (NFC) API</a> to enable wireless communication between two devices at close proximity has started in the <a href="https://www.w3.org/community/web-nfc/">Web NFC Community Group</a>.</p>


### PR DESCRIPTION
This spec recasts the Geolocation API on top of the Generic Sensor API.
