### PR TITLE
Add icons to navigation menu

### DIFF
--- a/assets/css/roadmap.css
+++ b/assets/css/roadmap.css
@@ -77,7 +77,6 @@ header button[name="sidenav-opener"] {
   padding: 10px;
   background-color: transparent;
   border: 0px;
-  display: flex;
 }
 
 header .brand img {/*
@@ -209,7 +208,7 @@ filter: grayscale(1);*/
   flex-flow: row nowrap;
   align-items: center;
   text-decoration: none;
-
+  color: #547190;
 }
 
 #side-nav nav ul li a .icon {
@@ -222,6 +221,9 @@ filter: grayscale(1);*/
 
 #side-nav nav ul li a img {
   width: 25px;
+  height: auto;
+  -webkit-filter: grayscale(1);
+  filter: grayscale(1);
 }
 
 #side-nav nav ul li a .description {

--- a/js/generate-index.js
+++ b/js/generate-index.js
@@ -3,8 +3,8 @@ const $ = (el, selector) =>
 
 const scripts = ['../js/sidenav.js'];
 
-const templateItem = '<a href=""><div class="icon"><img src="" width="45" alt=""></div><div class="description"><h2></h2><p></p></div></a>';
-const templateTocItem = '<a href=""><div class="description"></div></a>';
+const templateItem = '<a href=""><div class="icon"><img src="" alt=""></div><div class="description"><h2></h2><p></p></div></a>';
+const templateTocItem = '<a href=""><div class="icon"><img src="" alt=""></div><div class="description"></div></a>';
 
 
 /**
@@ -130,6 +130,7 @@ loadLocalizedUrl('../js/template-index.html', lang)
       let navLi = document.createElement('li');
       navLi.innerHTML = templateTocItem;
       navLi.querySelector('a').href = page.url;
+      navLi.querySelector('img').src = page.icon;
       navLi.querySelector('div.description').textContent = page.title;
       nav.appendChild(navLi);
     });

--- a/js/generate-index.js
+++ b/js/generate-index.js
@@ -123,7 +123,7 @@ loadLocalizedUrl('../js/template-index.html', lang)
       li.innerHTML = templateItem;
       li.querySelector('a').href = page.url;
       li.querySelector('h2').textContent = page.title;
-      li.querySelector('img').src = page.icon;
+      li.querySelector('.icon img').src = page.icon;
       li.querySelector('p').textContent = page.description;
       ul.appendChild(li);
 

--- a/js/generate.js
+++ b/js/generate.js
@@ -282,7 +282,7 @@ const applyToc = function (toc) {
     let navLi = document.createElement('li');
     navLi.innerHTML = templateTocItem;
     navLi.querySelector('a').href = page.url;
-    navLi.querySelector('img').src = page.icon;
+    navLi.querySelector('.icon img').src = page.icon;
     navLi.querySelector('div.description').textContent = page.title;
     nav.appendChild(navLi);
   });

--- a/js/generate.js
+++ b/js/generate.js
@@ -59,7 +59,7 @@ const scripts = ['../js/sidenav.js'];
 /**
  * Template to use for an item in the navigation menu
  */
-const templateTocItem = '<a href=""><div class="description"></div></a>';
+const templateTocItem = '<a href=""><div class="icon"><img src="" alt=""></div><div class="description"></div></a>';
 
 /**
  * List of maturity levels
@@ -273,11 +273,16 @@ const applyToc = function (toc) {
     }
   });
 
+  if (toc.pages.length === 0) {
+    document.getElementById('side-nav-btn').hidden = true;
+  }
+
   let nav = document.querySelector('aside nav ul');
   toc.pages.forEach(page => {
     let navLi = document.createElement('li');
     navLi.innerHTML = templateTocItem;
     navLi.querySelector('a').href = page.url;
+    navLi.querySelector('img').src = page.icon;
     navLi.querySelector('div.description').textContent = page.title;
     nav.appendChild(navLi);
   });


### PR DESCRIPTION
The side menu now displays icons. The same grey filter as the one applied to home page icons on narrow screens is applied to icons in the side navigation menu so that the menu remains "gentle to the eye".

Also, the menu hamburger is now automatically hidden in pages when there are no other pages in the roadmap.

Fixes #71.