### PR TITLE
[Framework] Impl and polyfills can now be listed in data/ files

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Depending on the advancement of the underlying specification, the JSON object ca
   * `chromestatus`: the number used to identify features in [Chrome Platform Status](https://www.chromestatus.com/features) (the one that appears in the URL after `features/`)
   * `edgestatus`: the name used to identify features in [Microsoft Edge web platform features status and roadmap](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/) (the one that appears in the URL after `platform/status/`)
   * `webkitstatus`: the name used to identify features in [WebKit Feature Status](https://webkit.org/status/) (the one that appears in the URL after `status/#`)
-  * `other`: an object that describes known implementation status per user agent.
+  * `other`: an object that describes known implementation status per user agent. Object keys should be user agent names (typically one of `edge`, `firefox`, `chrome`, `safari`), and object values one of `shipped`, `indevelopment`, `experimental` or `consideration`, to mark the current implementation status. Maintaining implementation information is difficult and error prone. Whenever possible, the implementation status of a feature should rather be automatically extracted from main sources. This `other` mechanism should only be used as a fallback when implementation status is not available.
 * for specifications for which there are polyfills available that would be worth reporting, the `polyfills` property lists these polyfills. It should be an array of objects that have a `url` property that links to the polyfill's home page on the Web, and a `label` property with the name of polyfill.
 * in case the reference to the specification would benefit from being more specific than the specification as a whole, the `feature` property allows to add the name of the specific feature (see e.g. the [reference to the HTMLMediaElement interface in the HTML5 specification](data/htmlmediaelement.json))
 * for specifications that have not started their Recommendation track progress, the `title` property gives the title of the specification
@@ -81,6 +81,22 @@ Here is an example of a JSON file that describes the "Intersection Observer" spe
       "url": "https://polyfill.io/v2/docs/features/#IntersectionObserver"
     }
   ]
+}
+```
+
+If you would like to state that a particular feature is implemented in Chrome, under development in Firefox, and being considered in Edge, you would add:
+
+```json
+{
+  "TR": "...",
+  "impl": {
+    "caniuse": "...",
+    "other": {
+      "chrome": "shipped",
+      "firefox": "indevelopment",
+      "edge": "consideration"
+    }
+  }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -53,15 +53,36 @@ That JSON object is stored in a file in the [data](data/) directory, whose name 
 
 Depending on the advancement of the underlying specification, the JSON object can have the following properties:
 * for W3C specifications that have started their Recommendation track progress, the `TR` property should point to the URL of latest version of the spec; this URL will be used to collect data about the spec (standardization status, Working Groups that produce it, editors draft, etc)
-* for specifications for which browser implementations are expected, the `impl` property is an object with the following optional properties:
+* for specifications for which browser implementations are expected, the `impl` property is an object with one or more of the following optional properties:
   * `caniuse`: the name of the feature in [Can I use](http://caniuse.com/) (the one that appears in the URL after `#feat=`)
   * `chromestatus`: the number used to identify features in [Chrome Platform Status](https://www.chromestatus.com/features) (the one that appears in the URL after `features/`)
   * `edgestatus`: the name used to identify features in [Microsoft Edge web platform features status and roadmap](https://developer.microsoft.com/en-us/microsoft-edge/platform/status/) (the one that appears in the URL after `platform/status/`)
   * `webkitstatus`: the name used to identify features in [WebKit Feature Status](https://webkit.org/status/) (the one that appears in the URL after `status/#`)
+  * `other`: an object that describes known implementation status per user agent.
+* for specifications for which there are polyfills available that would be worth reporting, the `polyfills` property lists these polyfills. It should be an array of objects that have a `url` property that links to the polyfill's home page on the Web, and a `label` property with the name of polyfill.
 * in case the reference to the specification would benefit from being more specific than the specification as a whole, the `feature` property allows to add the name of the specific feature (see e.g. the [reference to the HTMLMediaElement interface in the HTML5 specification](data/htmlmediaelement.json))
 * for specifications that have not started their Recommendation track progress, the `title` property gives the title of the specification
 * for specifications that have not started their Recommendation track progress, the `editors` property should point to the URL of the editors draft of the specification
 * for specifications that have not started their Recommendation track progress, the `wgs` property should be an array of objects describing the groups that are producing the spec; each such object should have a `url` property with a link to the group's home page, and a `label` property with the name of the group
+
+Here is an example of a JSON file that describes the "Intersection Observer" specification:
+```json
+{
+  "TR": "https://www.w3.org/TR/intersection-observer/",
+  "impl": {
+    "caniuse": "intersectionobserver",
+    "chromestatus": 5695342691483648,
+    "webkitstatus": "specification-intersection-observer",
+    "edgestatus": "Intersection Observer"
+  },
+  "polyfills": [
+    {
+      "label": "Polyfill.io",
+      "url": "https://polyfill.io/v2/docs/features/#IntersectionObserver"
+    }
+  ]
+}
+```
 
 ## Creating a new roadmap page or a new single-page roadmap
 Start from the following template
@@ -212,7 +233,8 @@ The `js/translations.xx.json` file, where `xx` is the BCP47 language code, needs
   },
   "labels": {
     "N/A": "",
-    "%feature in %spec": ""
+    "%feature in %spec": "",
+    "Polyfills": ""
   },
   "groups": {
     "CSS Working Group": "",

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -92,6 +92,11 @@ tbody th, tbody td { padding-left: 0.5em;}
 td.maturity { text-align: center; padding: 0;}
 td.maturity img { vertical-align: middle; }
 td img + img { margin-left: 0.25em; }
+td ul {
+    list-style-type: none;
+    padding-left: 0;
+    margin-top: -8px;
+}
 
 dl dt { margin-bottom: 0.3em;  font-size:1.1em;}
 dl dd{ margin-bottom: 1em;}

--- a/data/intersectionobserver.json
+++ b/data/intersectionobserver.json
@@ -5,5 +5,11 @@
     "chromestatus": 5695342691483648,
     "webkitstatus": "specification-intersection-observer",
     "edgestatus": "Intersection Observer"
-  }
+  },
+  "polyfills": [
+    {
+      "label": "Polyfill.io",
+      "url": "https://polyfill.io/v2/docs/features/#IntersectionObserver"
+    }
+  ]
 }

--- a/data/ttml-imsc1.json
+++ b/data/ttml-imsc1.json
@@ -6,5 +6,11 @@
     "edgestatus": null,
     "webkitstatus": null
   },
-  "TR": "https://www.w3.org/TR/ttml-imsc1/"
+  "TR": "https://www.w3.org/TR/ttml-imsc1/",
+  "polyfills": [
+    {
+      "label": "imscJS",
+      "url": "https://github.com/sandflow/imscJS"
+    }
+  ]
 }

--- a/js/generate.js
+++ b/js/generate.js
@@ -768,24 +768,50 @@ const formatImplInfo = function (data, translations) {
     div.appendChild(p);
     return div;
   }
-  Object.keys(data).forEach(type => {
-    let uadata = data[type];
-    uadata = uadata.filter(ua => browsers.indexOf(ua) !== -1);
-    if (uadata.length) {
-        let heading = document.createElement('p');
-        heading.appendChild(document.createTextNode(
-          statusTranslations[type] || type));
-        heading.appendChild(document.createElement('br'));
-        uadata.forEach(ua => {
-          let icon = document.createElement('img');
-          icon.src = '../assets/impl/' + ua + '.png';
-          icon.height = 30;
-          icon.alt = type + ' in ' + ua;
-          heading.appendChild(icon);
-        });
-        div.appendChild(heading);
-    }
-  });
+  Object.keys(data)
+    .filter(type => (type !== 'implementations') && (type !== 'polyfills'))
+    .forEach(type => {
+      let uadata = data[type];
+      uadata = uadata.filter(ua => browsers.indexOf(ua) !== -1);
+      if (uadata.length) {
+          let paragraph = document.createElement('p');
+          paragraph.appendChild(document.createTextNode(
+            statusTranslations[type] || type));
+          paragraph.appendChild(document.createElement('br'));
+          uadata.forEach(ua => {
+            let icon = document.createElement('img');
+            icon.src = '../assets/impl/' + ua + '.png';
+            icon.height = 30;
+            icon.alt = type + ' in ' + ua;
+            paragraph.appendChild(icon);
+          });
+          div.appendChild(paragraph);
+      }
+    });
+
+  if (data.polyfills) {
+    let el = document.createElement('p');
+    el.appendChild(document.createTextNode(
+      labelTranslations['Polyfills'] || 'Polyfills'));
+    div.appendChild(el);
+    el = document.createElement('ul');
+    data.polyfills.forEach((polyfill, pos) => {
+      let li = document.createElement('li');
+      let link = document.createElement('a');
+      link.setAttribute('href', polyfill.url);
+      if (polyfill.img && polyfill.img.src) {
+        let icon = document.createElement('img');
+        icon.src = polyfill.img.url;
+        icon.height = 30;
+        icon.alt = polyfill.img.label || '';
+        link.appendChild(icon);
+      }
+      link.appendChild(document.createTextNode(polyfill.label));
+      li.appendChild(link);
+      el.appendChild(li);
+    });
+    div.appendChild(el);
+  }
 
   return div;
 };


### PR DESCRIPTION
The implementation status can now be specified in the data/ file that describes a feature, in an `other` property of an `impl` property. That property should take an object that sets the additional implementation status per user agent.

For instance:
```json
{
  "impl": {
    "other": {
      "safari": "shipped",
      "chrome": "indevelopment",
      "firefox": "experimental"
    }
  }
}
```

Alternatively (but not necessarily encouraged for now as long as information remains simple), the property can take an array of implementation info as in:

```json
{
  "impl": {
    "other": [
      { "ua": "safari", "status": "indevelopment", "source": "rumors" },
      { "ua": "edge", "status": "experimental", "source": "dreams" }
    ]
  }
}
```

This implementation info completes the implementation info gathered automatically in `spec/impl.json`.

Polyfills can now be listed in the data/ file as well, in a `polyfills` property. The value of that property should be an array of objects with a `url` and a `label` property (possibly an `img` property as well). That info gets copied over to `spec/impl.json` and rendered in the implementations column of generated tables next to user-agent implementations.

The update addresses the following two issues:
- #7 Some way to specify implementation status locally
- #84 Possibility to list JS libraries as implementations