### PR TITLE
[Media] Rename "Media control" section into "Playback controls"

### DIFF
--- a/media/control.html
+++ b/media/control.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="utf-8">
-    <title>Media control</title>
+    <title>Playback controls</title>
   </head>
   <body>
     <header>
-      <h1>Media control</h1>
+      <h1>Playback controls</h1>
       <p>Media content provides many opportunities for rich interactions with users, either on- or off-device.</p>
     </header>
     <main>

--- a/media/toc.json
+++ b/media/toc.json
@@ -13,7 +13,7 @@
     },
     {
       "url": "control.html",
-      "title": "Media control",
+      "title": "Playback controls",
       "icon": "../assets/img/media-control.svg",
       "description": "Features needed to let the user interact with the playback of media content, both via local and remote interactions."
     },


### PR DESCRIPTION
The new name clarifies that the section is about user interaction to control media playback, not about controlling the media settings such as the codec, bitrate, etc.

Addresses issue #125.