### PR TITLE
[Framework] Drop specific maturity icon rule for Note documents

### DIFF
--- a/js/generate.js
+++ b/js/generate.js
@@ -337,7 +337,7 @@ const maturityData = function (spec) {
       label: spec.maturity,
       level: maturityLevels[spec.maturity] || 'low'
     },
-    maturityIcon: (!spec.maturity || (spec.maturity === 'NOTE')) ? null : {
+    maturityIcon: !spec.maturity ? null : {
       src: 'https://www.w3.org/2013/09/wpd-rectrack-icons/' +
         spec.maturity.toLowerCase().replace(/lastcall/,'lcwd') +
         '.svg',


### PR DESCRIPTION
The code was explicitly not referencing any icon for notes, but a Note maturity is now available:
https://www.w3.org/2013/09/wpd-rectrack-icons/note.svg

The update partially relates to #111 (as the "Note" icon was missing too)