### PR TITLE
[Data] Add Task Scheduler and Geofencing specs

### DIFF
--- a/data/geofencing.json
+++ b/data/geofencing.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/geofencing/"
+}

--- a/data/task-scheduler.json
+++ b/data/task-scheduler.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/task-scheduler/"
+}

--- a/mobile/lifecycle.html
+++ b/mobile/lifecycle.html
@@ -67,10 +67,10 @@
 
         <dl>
           <dt>Task Scheduling</dt>
-          <dd>The <a data-featureid="task-scheduler">Task Scheduler API</a> makes it possible to trigger a task at a specified time via the service worker associated with a Web app. This specification was in scope of the now-closed System Applications Working Group and was shelved as a result.</dd>
+          <dd>The <a data-featureid="task-scheduler">Task Scheduler API</a> made it possible to trigger a task at a specified time via the service worker associated with a Web app. This specification was in scope of the now-closed System Applications Working Group and was shelved as a result.</dd>
 
           <dt>Geofencing API</dt>
-          <dd>The <a href="https://w3c.github.io/geofencing-api/" data-featureid="geofencing">geofencing API</a> made it possible to wake up a Web app when a device enters a specified geographical area. This work has been discontinued, partly out of struggles to find a good approach to permission needs that such an API triggers to protect users against privacy issues. Work on this specification could resume in the future depending on interest from would-be implementers.</dd>
+          <dd>The <a data-featureid="geofencing">Geofencing API</a> made it possible to wake up a Web app when a device enters a specified geographical area. This work has been discontinued, partly out of struggles to find a good approach to permission needs that such an API triggers to protect users against privacy issues. Work on this specification could resume in the future depending on interest from would-be implementers.</dd>
         </dl>
       </section>
     </main>


### PR DESCRIPTION
The first spec was developed by the SysApp Working Group.
The second spec was developed by the Geolocation Working Group.

Both specs have been retired, but are referenced as discontinued features in the Lifecycle section of the mobile roadmap.

This fixes #133.