### PR TITLE
Filter UA in implementation status column based on query string param

### DIFF
--- a/js/filter-implstatus.js
+++ b/js/filter-implstatus.js
@@ -1,0 +1,87 @@
+/*******************************************************************************
+Script that runs on generated pages to filter the list of user-agents that
+appear in "Current implementations" columns.
+
+The filtering is done based on the presence of a "ua" parameter in the query
+string. That parameter should contain a comma-separated list of user-agents
+that should appear in the generated tables.
+
+For instance:
+- "ua=firefox" to only display the current implementation status in Firefox
+- "ua=chrome,edge" to display the current implementation status in Chrome and
+in Edge.
+
+The script also updates navigation links to preserve the query string across
+pages.
+*******************************************************************************/
+(function () {
+  const $ = (el, selector) =>
+    Array.prototype.slice.call(el.querySelectorAll(selector), 0);
+
+  const isString = function (obj) {
+    return Object.prototype.toString.call(obj) === '[object String]';
+  };
+
+  const filterImplementations = function (ua) {
+    if (ua && isString[ua]) {
+      ua = [ua];
+    }
+
+    // Reset elements, making sure they are all visible
+    $(document, '[data-implstatus],[data-ua]')
+      .forEach(el => el.hidden = false);
+
+    // Nothing to filter if all UA are to be displayed
+    if (!ua || (ua.length === 0)) {
+      return;
+    }
+
+    // Hide UA implementations that are not requested
+    $(document, '[data-ua]')
+      .filter(el => !ua.includes(el.getAttribute('data-ua')))
+      .forEach(el => el.hidden = true);
+
+    // Hide wrapping label if there are no more visible implementation status
+    // to show under that label
+    $(document, '[data-implstatus]')
+      .filter(el => !el.querySelector('[data-ua]:not([hidden])'))
+      .forEach(el => el.hidden = true);
+  };
+
+  let filtered = false;
+
+  const loadHandler = function () {
+    if (filtered || !document.querySelector('[data-generated]')) {
+      return;
+    }
+    filtered = true;
+
+    // Get requested user-agents from query string
+    let ua = (window.location.search || '').substring(1)
+      .split('&')
+      .filter(param => param.split('=')[0] === 'ua')
+      .map(param => param.split('=')[1])
+      .pop()
+      .split(',');
+
+    // Update links in navigation menus to preserve the current query string
+    // across pages
+    $(document, '[data-nav]').forEach(el => {
+      let url = el.getAttribute('href').replace(/\?.*$/, '') +
+        window.location.search;
+      el.setAttribute('href', url);
+    });
+
+    // Filter implementation status results as requested
+    filterImplementations(ua);
+  };
+
+  // Apply the filtering when the document is loaded and has been generated,
+  // meaning when there is a "data-generated" attribute. If the "generate.js"
+  // script is present, it will add the attribute and trigger a "generate"
+  // event when it is done running. If the "generate.js" script is not present,
+  // in other words when the page is a published version of the generated page,
+  // the "data-generated" attribute should already exist.
+  document.addEventListener('generate', loadHandler);
+  document.addEventListener('load', loadHandler);
+})();

--- a/js/generate.js
+++ b/js/generate.js
@@ -116,4 +116,7 @@ loadScript('../js/utils.js').then(_ => {
 }).then(results => {
   let customTables = results[0]['tables'];
   return fillTables(results[2], results[3], customTables, results[4], lang);
+}).then(_ => {
+  document.documentElement.setAttribute('data-generated', '');
+  document.dispatchEvent(new Event('generate'));
 });

--- a/js/utils.js
+++ b/js/utils.js
@@ -70,17 +70,17 @@ const makeID = function(elem, pfx = "", txt = "", noLC = false) {
 /**
  * List of scripts to include in all pages once the page has been generated
  */
-const scripts = ['../js/sidenav.js'];
+const scripts = ['../js/sidenav.js', '../js/filter-implstatus.js'];
 
 /**
  * Template to use for an item in the main navigation menu
  */
-const templateItem = '<a href=""><div class="icon"><img src="" alt=""></div><div class="description"><h2></h2><p></p></div></a>';
+const templateItem = '<a href="" data-nav><div class="icon"><img src="" alt=""></div><div class="description"><h2></h2><p></p></div></a>';
 
 /**
  * Template to use for an item in the side navigation menu
  */
-const templateTocItem = '<a href=""><div class="icon"><img src="" alt=""></div><div class="description"></div></a>';
+const templateTocItem = '<a href="" data-nav><div class="icon"><img src="" alt=""></div><div class="description"></div></a>';
 
 
 /**
@@ -582,7 +582,7 @@ const applyToc = function (toc, translations, lang, pagetype) {
           // Replace language in the current URL with the target language
           url = window.location.pathname.replace(/\.([^\.]+)\.([^\.]+)$/, '.' + tr.lang + '.$2');
         }
-        return '<a href="' + url + '">' + tr.title + '</a>';
+        return '<a href="' + url + '" data-nav>' + tr.title + '</a>';
       }
     });
     $(document, '.translations').forEach(el => el.innerHTML = trtext.join (' | '));
@@ -796,7 +796,7 @@ const fillTables = function (specInfo, implInfo, customTables, tr, lang) {
   // apply that info to generate the tables at the end of sections
   referencedFeatureIds = referencedFeatureIds.filter(
     (fid, idx, self) => self.indexOf(fid) === idx);
-  Promise.all(referencedFeatureIds
+  return Promise.all(referencedFeatureIds
       .map(featureId => {
         return {
           id: featureId,
@@ -930,6 +930,7 @@ const formatImplInfo = function (data, translations) {
       uadata = uadata.filter(ua => browsers.indexOf(ua) !== -1);
       if (uadata.length) {
           let paragraph = document.createElement('p');
+          paragraph.setAttribute('data-implstatus', '');
           paragraph.appendChild(document.createTextNode(
             statusTranslations[type] || type));
           paragraph.appendChild(document.createElement('br'));
@@ -938,6 +939,7 @@ const formatImplInfo = function (data, translations) {
             icon.src = '../assets/impl/' + ua + '.png';
             icon.height = 30;
             icon.alt = type + ' in ' + ua;
+            icon.setAttribute('data-ua', ua);
             paragraph.appendChild(icon);
           });
           div.appendChild(paragraph);


### PR DESCRIPTION
The new `filter-implstatus.js` script runs once a page has been generated (either dynamically or statically if the current page is a published export), and filters the list of user agents that appear in "Current implementations" columns in generated tables based on the presence of a "ua" query string parameter.

The script expects the query string parameter to contain a comma-separated list of the user-agents that need to appear. For instance:
- `ua=firefox` to only display the current implementation status in Firefox
- `ua=chrome,edge` to display the current implementation status in Chrome and in Edge.

The script also updates navigation links to preserve the query string across pages.

This update addresses issue #143, although note the filtering would benefit from further enhancements in the future:
- to be available through a filtering button on the user interface
- to create a more specific column when there is only one user-agent to render
(e.g. an "Implementation status in Firefox" column that only contains text
instead of the current filtering that will render the "Firefox" icon each time
next to the implementation status label)