### PR TITLE
[Mobile] Mention Payment Method Identifiers and Manifest specs

### DIFF
--- a/data/payment-method-id.json
+++ b/data/payment-method-id.json
@@ -1,0 +1,3 @@
+{
+  "TR": "https://www.w3.org/TR/payment-method-id/"
+}

--- a/data/payment-method-manifest.json
+++ b/data/payment-method-manifest.json
@@ -1,0 +1,6 @@
+{
+  "TR": "https://www.w3.org/TR/payment-method-manifest/",
+  "impl": {
+    "chromestatus": 5716168929181696
+  }
+}

--- a/data/payment-request.json
+++ b/data/payment-request.json
@@ -1,7 +1,9 @@
 {
   "impl": {
     "caniuse": "payment-request",
-    "chromestatus": 5639348045217792
+    "chromestatus": 5639348045217792,
+    "edgestatus": "Payment Request API",
+    "webkitstatus": "feature-payment-request"
   },
   "TR": "https://www.w3.org/TR/payment-request/"
 }

--- a/mobile/payment.html
+++ b/mobile/payment.html
@@ -25,6 +25,9 @@
 
         <ul data-feature="Web Payment">
           <li>The <a data-featureid="payment-request">Payment Request API</a> defines an API to allow merchants (i.e. web sites selling physical or digital goods) to utilize one or more payment methods with minimal integration. In this model, browsers facilitate the payment flow between merchant and user.</li>
+          <li>The <a data-featureid="payment-method-id">Payment Method Identifiers</a> specification defines payment method identifiers and how they are validated, and, where 
+          applicable, minted and formally registered with the W3C.</li>
+          <li>The <a data-featureid="payment-method-manifest">Payment Method Manifest</a> specification defines a machine-readable manifest file that describes default payment applications that are associated with a given payment method, as well as the list of origins that are permitted to provide payment applications for this payment method.</li>
           <li>The <a data-featureid="payment-method-basic-card">Basic Card Payment</a> specification describes data structures that enable the use of debit and credit cards in the Payment Request API.</li>
           <li>The <a data-featureid="payment-handler">Payment Handler API</a> defines a standard way to initiate payment requests from Web pages and applications.</li>
         </ul>


### PR DESCRIPTION
The First Public Working Draft of the Payment Method Manifest specification was published early December 2017, and did not yet appear in the mobile roadmap, as raised in #157.

Also added the Payment Method Identifiers specification to provide a complete overview of payment technologies under development.

Payment spec data adjusted based on contents browser status platforms as well.