### PR TITLE
[Mobile] Mark humidity, thermometer, barometer proposals as discontinued

### DIFF
--- a/data/barometer.json
+++ b/data/barometer.json
@@ -1,0 +1,10 @@
+{
+  "editors": "https://kenchris.github.io/barometer/",
+  "title": "Ambient Atmospheric Pressure (Barometric) Sensor",
+  "wgs": [
+    {
+      "label": "Device and Sensors Working Group",
+      "url": "http://www.w3.org/2009/dap/"
+    }
+  ]
+}

--- a/data/thermometer.json
+++ b/data/thermometer.json
@@ -1,0 +1,10 @@
+{
+  "editors": "https://kenchris.github.io/thermometer/",
+  "title": "Ambient Temperature (Thermometer) sensor",
+  "wgs": [
+    {
+      "label": "Device and Sensors Working Group",
+      "url": "http://www.w3.org/2009/dap/"
+    }
+  ]
+}

--- a/mobile/sensors.html
+++ b/mobile/sensors.html
@@ -51,8 +51,6 @@
         <p data-feature="NFC">Work on a <a href="http://w3c.github.io/web-nfc/" data-featureid="webnfc">Web Near-Field Communications (NFC) API</a> to enable wireless communication between two devices at close proximity has started in the <a href="https://www.w3.org/community/web-nfc/">Web NFC Community Group</a>.</p>
 
         <p data-feature="Bluetooth">Similarly, the <a data-featureid="webbluetooth">Web Bluetooth</a> specification, developed by the <a href="https://www.w3.org/community/web-bluetooth">Web Bluetooth Community Group</a>, describes an API to discover and communicate with devices over the Bluetooth Low Energy (BLE) mode.</p>
-
-        <p>The proposed <a data-feature="Humidity sensor" data-featureid="humidity">Ambient Humidity Events</a> would allow mobile Web applications to receive events that correspond to changes in ambient humidity.</p>
       </section>
 
       <section>
@@ -60,6 +58,9 @@
         <dl>
           <dt>Geofencing API</dt>
           <dd>The ability to detect when a device enters a given geographical area would enable interactions and notifications based on the user's physical presence in a given place. The Geolocation Working Group started to work on a <a href="https://w3c.github.io/geofencing-api/" data-featureid="geofencing">geofencing API</a> to that effect. This work has been discontinued, partly out of struggles to find a good approach to permission needs that such an API triggers to protect users against privacy issues, and because the API depended on the <a href="https://w3c.github.io/ServiceWorker/">Service Workers</a>, which was not yet stable at the time. Work on this specification could resume in the future depending on interest from would-be implementers.</dd>
+
+          <dt>Additional sensor specifications</dt>
+          <dd>A number of additional sensor specifications have been considered in the past in the <a href="http://www.w3.org/2009/dap/">Device and Sensors Working Group</a>, for instance to expose <a data-featureid="humidity">changes in ambient humidity</a> (proposal which predates the <a data-featureid="generic-sensor">Generic Sensor API</a>), the <a data-featureid="barometer">Barometer Sensor</a> or the <a data-featureid="thermometer">Thermometer Sensor</a>. Work on these proposals could resume in the future depending on interest from would-be implementers.</dd>
         </dl>
       </section>
     </main>


### PR DESCRIPTION
See #159. The roadmap mentioned the Ambient Humidity Events spec in the Exploratory Work section but work has been discontinued. This update moves that spec to the Discontinued feature section, and completes the note to mention the Thermometer and Barometer proposals. Work on these proposals may resume any time if there is enough implementer support.