### PR TITLE
[mobile] Update the links to HTML 5.2

### DIFF
--- a/data/animation-frames.json
+++ b/data/animation-frames.json
@@ -1,5 +1,5 @@
 {
-  "TR": "https://www.w3.org/TR/html51/webappapis.html#animation-frames",
+  "TR": "https://www.w3.org/TR/html52/webappapis.html#animation-frames",
   "impl": {
     "caniuse": "requestanimationframe"
   },

--- a/data/audio.json
+++ b/data/audio.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "audio"
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-audio-element",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#the-audio-element",
   "feature": "audio element"
 }

--- a/data/autocomplete.json
+++ b/data/autocomplete.json
@@ -1,5 +1,5 @@
 {
   "impl": {},
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#element-attrdef-autocompleteelements-autocomplete",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#autofilling-form-controls-the-autocomplete-attribute",
   "feature": "autocomplete attribute"
 }

--- a/data/datalist.json
+++ b/data/datalist.json
@@ -4,6 +4,6 @@
     "chromestatus": 6090950820495360,
     "edgestatus": "<datalist> Element"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-datalist-element",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#the-datalist-element",
   "feature": "datalist element"
 }

--- a/data/html5-download.json
+++ b/data/html5-download.json
@@ -4,6 +4,6 @@
     "chromestatus": 6473924464345088,
     "webkitstatus": "feature-download-attribute"
   },
-  "TR": "https://www.w3.org/TR/html51/links.html#downloading-resources",
+  "TR": "https://www.w3.org/TR/html52/links.html#downloading-resources",
   "feature" : "download attribute"
 }

--- a/data/htmlmediaelement.json
+++ b/data/htmlmediaelement.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-media-elements",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#the-media-elements",
   "feature": "HTMLMediaElement interface"
 }

--- a/data/inputdate.json
+++ b/data/inputdate.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-datetime"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#date-state-typedate",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#date-state-typedate",
   "feature": "Date and time input types"
 }

--- a/data/inputhint.json
+++ b/data/inputhint.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-placeholder"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-placeholder-attribute",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#the-placeholder-attribute",
   "feature": "input placeholder attribute"
 }

--- a/data/inputpattern.json
+++ b/data/inputpattern.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-pattern"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#the-pattern-attribute",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#the-pattern-attribute",
   "feature": "pattern attribute for input fields"
 }

--- a/data/inputtext.json
+++ b/data/inputtext.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "input-email-tel-url"
   },
-  "TR": "https://www.w3.org/TR/html51/sec-forms.html#email-state-typeemail",
+  "TR": "https://www.w3.org/TR/html52/sec-forms.html#email-state-typeemail",
   "feature": "tel, email, url input types"
 }

--- a/data/online.json
+++ b/data/online.json
@@ -1,5 +1,5 @@
 {
-  "TR": "https://www.w3.org/TR/html51/browsers.html#browser-state",
+  "TR": "https://www.w3.org/TR/html52/browsers.html#browser-state",
   "impl": {
     "caniuse": "online-status"
   },

--- a/data/picture.json
+++ b/data/picture.json
@@ -4,6 +4,6 @@
     "chromestatus": 5910974510923776,
     "webkitstatus": "feature-picture-element"
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-picture-element",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#the-picture-element",
   "feature": "picture element"
 }

--- a/data/srcset.json
+++ b/data/srcset.json
@@ -2,6 +2,6 @@
   "impl": {
     "chromestatus": 4644337115725824
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#element-attrdef-img-srcset",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#element-attrdef-img-srcset",
   "feature": "srcset attribute"
 }

--- a/data/timeupdate.json
+++ b/data/timeupdate.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#eventdef-media-timeupdate",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#eventdef-media-timeupdate",
   "feature": "timeupdate event"
 }

--- a/data/video.json
+++ b/data/video.json
@@ -2,6 +2,6 @@
   "impl": {
     "caniuse": "video"
   },
-  "TR": "https://www.w3.org/TR/html51/semantics-embedded-content.html#the-video-element",
+  "TR": "https://www.w3.org/TR/html52/semantics-embedded-content.html#the-video-element",
   "feature": "video element"
 }

--- a/mobile/forms.html
+++ b/mobile/forms.html
@@ -12,7 +12,7 @@
     <main>
       <section class="featureset well-deployed">
         <h2>Well-deployed technologies</h2>
-        <p data-feature="Customized text entries">The <code><a data-featureid="inputtext">&lt;input type="<strong>email</strong>"&gt;</a></code>, <code><a href="https://www.w3.org/TR/html51/sec-forms.html#telephone-state-typetel">&lt;input type="<strong>tel</strong>"&gt;</a></code> and <code><a href="https://www.w3.org/TR/html51/sec-forms.html#url-state-typeurl">&lt;input type="<strong>url</strong>"&gt;</a></code> can be used to optimize the ways user enter these often-difficult to type data, e.g. through dedicated virtual keyboards, or by accessing on-device records for these data (from the address book, bookmarks, etc.).</p>
+        <p data-feature="Customized text entries">The <code><a data-featureid="inputtext">&lt;input type="<strong>email</strong>"&gt;</a></code>, <code><a href="https://www.w3.org/TR/html52/sec-forms.html#telephone-state-typetel">&lt;input type="<strong>tel</strong>"&gt;</a></code> and <code><a href="https://www.w3.org/TR/html52/sec-forms.html#url-state-typeurl">&lt;input type="<strong>url</strong>"&gt;</a></code> can be used to optimize the ways user enter these often-difficult to type data, e.g. through dedicated virtual keyboards, or by accessing on-device records for these data (from the address book, bookmarks, etc.).</p>
 
         <p data-feature="Input validation">The <code><a data-featureid="inputpattern">pattern</a></code> attribute allows both to guide user input as well as to avoid server-side validation (which requires a network round-trip) or JavaScript-based validation (which takes up more resources), both useful optimization on constrained mobile devices.</p>
 

--- a/mobile/storage.html
+++ b/mobile/storage.html
@@ -43,8 +43,8 @@
           <dt>Client-side SQL-based database</dt>
           <dd>The work around a <a data-featureid="websql">client-side SQL-based database</a>, which had been started in 2009, has been abandoned in favor of the work on IndexedDB.</dd>
 
-          <dt>Addressbook data</dt>
-          <dd>Communication applications can benefit from integrating with their users’ existing data records; on mobile devices, the address book is a particularly useful source of information. For Web apps outside of the browser, a purely programmatic approach was part of the <a href="https://www.w3.org/2012/05/sysapps-wg-charter.html">System Applications Working Group</a>; since this group has now closed, no further work on the <a data-featureid="contacts-sys">Contacts Manager API</a> is expected for the time being. Within the browser, HTML 5.1 provides <a data-featureid="autocomplete">autocompleted fields for contacts information</a> that would let browsers re-use data from addressbooks.</dd>
+          <dt>Address book data</dt>
+          <dd>Communication applications can benefit from integrating with their users’ existing data records; on mobile devices, the address book is a particularly useful source of information. For Web apps outside of the browser, a purely programmatic approach was part of the <a href="https://www.w3.org/2012/05/sysapps-wg-charter.html">System Applications Working Group</a>; since this group has now closed, no further work on the <a data-featureid="contacts-sys">Contacts Manager API</a> is expected for the time being. Within the browser, HTML provides <a data-featureid="autocomplete">autocompleted fields for contacts information</a> that would let browsers re-use data from address books.</dd>
         </dl>
       </section>
     </main>


### PR DESCRIPTION
`appcache.json` and `inputmode.json` were not updated, because the relevant spec sections were removed in HTML 5.2.
