### PR TITLE
[mobile] Move requestIdleCallback to well-deployed

### DIFF
--- a/mobile/performance.html
+++ b/mobile/performance.html
@@ -29,6 +29,10 @@
           <p>The <a data-featureid="page-visibility">API to determine whether a Web page is being displayed</a> (Page Visibility API) can also be used to adapt the usage of resources to the need of the Web application, for instance by reducing network activity when the page is minimized.</p>
         </div>
 
+        <div data-feature="Priority Handling">
+          <p>The <a data-featureid="requestidlecallback">Cooperative Scheduling of Background Tasks specification</a> defines the <code>requestIdleCallback</code> method that allows scheduling an operation at the next opportunity when the app is not processing another operation.</p>
+        </div>
+
         <div data-feature="Animation Optimization">
           <p>The <a data-featureid="animation-frames">Timing control for script-based animations API</a> can help reduce the usage of resources needed for playing animations.</p>
         </div>
@@ -46,10 +50,6 @@
         <h2>Technologies in progress</h2>
         <div data-feature="Network Prioritization">
           <p>The <a data-featureid="resource-hints">Resource Hints</a> and <a data-featureid="preload">Preload</a> specifications let developers optimize the download of resources by enabling to delay either the download or the execution of the downloaded resource.</p>
-        </div>
-
-        <div data-feature="Priority Handling">
-          <p>The <a data-featureid="requestidlecallback">Cooperative Scheduling of Background Tasks specification</a> defines the <code>requestIdleCallback</code> method that allows scheduling an operation at the next opportunity when the app is not processing another operation.</p>
         </div>
 
         <div data-feature="Caching">


### PR DESCRIPTION
Cooperative Scheduling of Background Tasks is a Proposed Recommendation now, and shipped with Chrome and Firefox.

Should we move it to well-deployed now?