### PR TITLE
[Mobile] Fix proximity sensor implementation status

### DIFF
--- a/data/proximity.json
+++ b/data/proximity.json
@@ -1,6 +1,15 @@
 {
   "TR": "https://www.w3.org/TR/proximity/",
   "impl": {
-    "caniuse": "proximity"
+    "caniuse": "proximity",
+    "other": [
+      {
+        "ua": "firefox",
+        "status": "",
+        "source": "feedback",
+        "date": "2018-03-19",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      }
+    ]
   }
 }

--- a/data/proximity.json
+++ b/data/proximity.json
@@ -9,6 +9,13 @@
         "source": "feedback",
         "date": "2018-03-19",
         "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
+      },
+      {
+        "ua": "and_ff",
+        "status": "",
+        "source": "feedback",
+        "date": "2018-03-19",
+        "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
       }
     ]
   }


### PR DESCRIPTION
See #160 and previous update to the Ambient Light sensor implementation status. The version that ships in Firefox is not the latest version of the spec, which is based on the Generic Sensor API.
