### PR TITLE
[Mobile] Mention streams in Network

### DIFF
--- a/data/streams.json
+++ b/data/streams.json
@@ -1,0 +1,14 @@
+{
+  "title": "Streams",
+  "ls": "https://streams.spec.whatwg.org/",
+  "wgs": [
+    {
+      "label": "WHATWG",
+      "url": "https://whatwg.org/"
+    }
+  ],
+  "impl": {
+    "caniuse": "streams",
+    "chromestatus": 6605041225957376
+  }
+}

--- a/mobile/network.html
+++ b/mobile/network.html
@@ -41,6 +41,10 @@
 
       <section class="featureset in-progress">
         <h2>Technologies in progress</h2>
+        <div data-feature="Low-level I/O">
+          <p>The <a data-featureid="streams">Streams</a> specification provides APIs for creating, composing, and consuming streams of data efficiently. Network conditions may fluctuate in mobile networks and bandwidth may be restricted; access to low-level I/O primitives enable flow control within Web applications to adjust the network delivery to some reader's speed (e.g. a media player), and perceived rendering performance improvements, e.g. when a Service Worker assembles a stream from content previously cached and content fetched online to speed up the first set of render operations of a page. The ability to cancel a stream to stop download at any time also helps reclaim network bandwidth for other tasks as soon as needed.</p>
+        </div>
+
         <p data-feature="HTTP Network API">The <a data-featureid="beacon">Beacon API</a> aims at letting developers queue unsupervised HTTP requests, leaving it to the browser to execute them when appropriate, opening the door for better network optimizations.</p>
 
         <div data-feature="Server-pushed Requests">


### PR DESCRIPTION
See #162. Streams have some practical benefits in mobile devices as they allow more fine-grained control over network usage. Also they may be used to improve perceived rendering performances, as described in:
https://jakearchibald.com/2016/streams-ftw/

Note: Streams are mentioned on Webkit status and Edge status platforms, but at a more fine-grained feature level, which we don't yet support.

