### PR TITLE
[Mobile] Replace WebVR by WebXR in the media page

### DIFF
--- a/data/webvr.json
+++ b/data/webvr.json
@@ -1,16 +1,15 @@
 {
   "wgs": [
     {
-      "label": "WebVR Community Group",
+      "label": "Immersive Web Community Group",
       "url": "https://www.w3.org/community/webvr/"
     }
   ],
   "impl": {
-    "caniuse": null,
+    "caniuse": "webvr",
     "chromestatus": 4532810371039232,
-    "mozstatus": null,
-    "edgestatus": null,
-    "webkitstatus": null
+    "edgestatus": "WebVR",
+    "webkitstatus": "specification-webvr"
   },
   "title": "WebVR",
   "editors": "https://w3c.github.io/webvr/"

--- a/data/webxr.json
+++ b/data/webxr.json
@@ -1,0 +1,17 @@
+{
+  "editors": "https://w3c.github.io/webvr/",
+  "title": "WebXR Device API",
+  "wgs": [
+    {
+      "label": "Immersive Web Community Group",
+      "url": "https://www.w3.org/community/webvr/"
+    }
+  ],
+  "impl": {
+    "caniuse": null,
+    "chromestatus": 5680169905815552,
+    "mozstatus": null,
+    "edgestatus": null,
+    "webkitstatus": null
+  }
+}

--- a/mobile/media.html
+++ b/mobile/media.html
@@ -60,8 +60,8 @@
           <p>New mobile screens can render content in high resolution using a broader color space beyond the classical sRGB color space. To adapt to wide-gamut displays, all the graphical systems of the Web will need to adapt to these broader color spaces. <a data-featureid="css-color-space">CSS Colors Level 4</a> is proposing to define CSS colors in color spaces beyond the classical sRGB. Similarly, work on <a data-featureid="color-canvas">making canvas color-managed</a> should enhance the support for colors in HTML Canvas.</p>
         </div>
 
-        <div data-feature="Rendering in VR headsets">
-          <p>The <a data-featureid="webvr">WebVR</a> specification is a low-level API that allows applications to access and control head-mounted displays (HMD) using JavaScript. It is a critical enabler to render 360° video content in Virtual Reality headsets and in mobile devices used as such.</p>
+        <div data-feature="Rendering in VR/AR headsets">
+          <p>The <a data-featureid="webxr">WebXR Device API</a> specification is a low-level API that allows applications to access and control head-mounted displays (HMD) using JavaScript and create compelling Virtual Reality (VR) / Augmented Reality (AR) experiences. It is a critical enabler to render 360° video content in Virtual Reality headsets and in mobile devices used as such.</p>
         </div>
 
         <div data-feature="Capabilities and quality">
@@ -90,6 +90,9 @@
         <dl>
           <dt>Network service discovery</dt>
           <dd>The <a data-featureid="discovery">Network Service Discovery API</a> was to offer a lower-level approach to the establishment of multi-device operations, by providing integration with local network-based media renderers, such as those enabled by DLNA, UPnP, etc. This effort was discontinued out of privacy concerns and lack of interest from implementers. The current approach is to let the user agent handle network discovery under the hoods, as done in the <a data-featureid="secondscreen">Presentation API</a> and <a data-featureid="remote-playback">Remote Playback API</a>.</dd>
+
+          <dt>WebVR</dt>
+          <dd>Development of the <a data-featureid="webvr">WebVR</a> specification that allowed access and control of Virtual Reality (VR) devices, and which is supported in some browsers, has halted in favor of the <a data-featureid="webxr">WebXR Device API</a>, which extends the scope of the work to Augmented Reality (AR) devices.</dd>
         </dl>
       </section>
     </main>


### PR DESCRIPTION
See #188. I moved WebVR to the Discontinued features section since development on it halted, and pointed out that WebXR also addresses AR scenarios.

Also updated the WebVR CG name into the new "Immersive Web CG", even though they haven't enacted that change on the CG home page yet.