### PR TITLE
[Framework] Improve group info logic and expose publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Depending on the advancement of the underlying specification, the JSON object ca
 * `title`: when the specification is unknown to the [W3C API](https://w3c.github.io/w3c-api/) and to [Specref](https://www.specref.org/), the `title` property should be set to the title of the specification
 * `edDraft`: when the specification is unknown to the [W3C API](https://w3c.github.io/w3c-api/) and to [Specref](https://www.specref.org/), or when these APIs do not know the URL of the Editor's Draft for the specification, the `edDraft` property should contain the URL of the Editor's Draft of the specification.
 * `wgs`: when the specification is unknown to the [W3C API](https://w3c.github.io/w3c-api/) and to [Specref](https://www.specref.org/), the `wgs` property should be an array of objects describing the groups that are producing the spec; each such object should have a `url` property with a link to the group's home page, and a `label` property with the name of the group.
+* `publisher`: the organization that published the specification. The framework automatically computes the publisher for W3C, WHATWG, and IETF specifications.
 
 Here is an example of a JSON file that describes the "Intersection Observer" specification:
 ```json

--- a/data/background-sync.json
+++ b/data/background-sync.json
@@ -1,11 +1,5 @@
 {
     "title": "Web Background Synchronization",
-    "wgs": [
-        {
-            "url": "https://www.w3.org/community/wicg/",
-            "label": "Web Platform Incubator Community Group"
-        }
-    ],
     "editors": "https://wicg.github.io/BackgroundSync/spec/",
     "impl": {
         "chromestatus": 6170807885627392

--- a/data/feature-policy.json
+++ b/data/feature-policy.json
@@ -1,12 +1,5 @@
 {
     "editors": "https://wicg.github.io/feature-policy/",
-    "title": "Feature Policy",
-    "wgs": [
-        {
-            "url": "https://www.w3.org/community/wicg/",
-            "label": "Web Platform Incubator Community Group"
-        }
-    ],
     "impl": {
         "chromestatus": 5694225681219584
     }

--- a/data/geolocation-sensor.json
+++ b/data/geolocation-sensor.json
@@ -1,10 +1,3 @@
 {
-    "title": "Geolocation Sensor",
-    "wgs": [
-        {
-            "url": "https://www.w3.org/community/wicg/",
-            "label": "Web Platform Incubator Community Group"
-        }
-    ],
     "editors": "https://wicg.github.io/geolocation-sensor/"
 }

--- a/data/inband.json
+++ b/data/inband.json
@@ -1,5 +1,4 @@
 {
-  "title": "Sourcing In-band Media Resource Tracks from Media Containers into HTML",
   "wgs": [
     {
       "label": "Media Resource In-band Tracks Community Group",

--- a/data/inputdevice.json
+++ b/data/inputdevice.json
@@ -1,10 +1,3 @@
 {
-  "editors": "https://wicg.github.io/InputDeviceCapabilities/",
-  "title": "Input Device Capabilities",
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ]
+  "editors": "https://wicg.github.io/InputDeviceCapabilities/"
 }

--- a/data/media-capabilities.json
+++ b/data/media-capabilities.json
@@ -1,10 +1,4 @@
 {
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "impl": {
     "caniuse": null,
     "chromestatus": null,
@@ -12,6 +6,5 @@
     "edgestatus": null,
     "webkitstatus": null
   },
-  "title": "Media Capabilities",
   "editors": "https://wicg.github.io/media-capabilities/"
 }

--- a/data/media-playback-quality.json
+++ b/data/media-playback-quality.json
@@ -1,10 +1,4 @@
 {
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "impl": {
     "caniuse": null,
     "chromestatus": null,
@@ -12,6 +6,5 @@
     "edgestatus": null,
     "webkitstatus": null
   },
-  "title": "Media Playback Quality",
   "editors": "https://wicg.github.io/media-playback-quality/"
 }

--- a/data/mediasession.json
+++ b/data/mediasession.json
@@ -1,10 +1,4 @@
 {
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "impl": {
     "caniuse": null,
     "chromestatus": 5639924124483584,
@@ -12,6 +6,5 @@
     "edgestatus": null,
     "webkitstatus": null
   },
-  "title": "Media Session",
   "editors": "https://wicg.github.io/mediasession/"
 }

--- a/data/mobile-wcag.json
+++ b/data/mobile-wcag.json
@@ -1,4 +1,0 @@
-{
-  "title": "Mobile Accessibility: How WCAG 2.0 and Other W3C/WAI Guidelines Apply to Mobile",
-  "editors": "https://w3c.github.io/Mobile-A11y-TF-Note/"
-}

--- a/data/netinfo.json
+++ b/data/netinfo.json
@@ -1,11 +1,4 @@
 {
-    "title": "Network Information API",
-    "wgs": [
-        {
-            "url": "https://wicg.io/",
-            "label": "Web Platform Incubator Community Group"
-        }
-    ],
     "editors": "https://wicg.github.io/netinfo/",
     "impl": {
         "caniuse": "netinfo",

--- a/data/picture-in-picture.json
+++ b/data/picture-in-picture.json
@@ -1,10 +1,3 @@
 {
-  "editors": "https://wicg.github.io/picture-in-picture/",
-  "title": "Picture in Picture",
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ]
+  "editors": "https://wicg.github.io/picture-in-picture/"
 }

--- a/data/shape-detection.json
+++ b/data/shape-detection.json
@@ -1,11 +1,4 @@
 {
   "editors": "https://wicg.github.io/shape-detection-api",
-  "impl": {},
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ],
-  "title": "Shape Detection API"
+  "impl": {}
 }

--- a/data/viewportapi.json
+++ b/data/viewportapi.json
@@ -1,11 +1,6 @@
 {
   "editors": "https://wicg.github.io/visual-viewport/",
-  "wgs": [{
-    "url": "https://www.w3.org/community/wicg/",
-    "label": "Web Platform Incubator Community Group"
-  }],
   "impl": {
     "chromestatus": 5737866978131968
-  },
-  "title": "Visual Viewport API"
+  }
 }

--- a/data/web-share-target.json
+++ b/data/web-share-target.json
@@ -1,11 +1,6 @@
 {
   "editors": "https://wicg.github.io/web-share-target/",
-  "wgs": [{
-    "url": "https://www.w3.org/community/wicg/",
-    "label": "Web Platform Incubator Community Group"
-  }],
   "impl": {
     "chromestatus": 5662315307335680
-  },
-  "title": "Web Share Target API"
+  }
 }

--- a/data/web-share.json
+++ b/data/web-share.json
@@ -1,13 +1,8 @@
 {
   "editors": "https://wicg.github.io/web-share/",
-  "wgs": [{
-    "url": "https://www.w3.org/community/wicg/",
-    "label": "Web Platform Incubator Community Group"
-  }],
   "impl": {
     "caniuse": "web-share",
     "chromestatus": 5668769141620736,
     "webkitstatus": "feature-web-share"
-  },
-  "title": "Web Share API"
+  }
 }

--- a/data/webbluetooth.json
+++ b/data/webbluetooth.json
@@ -1,11 +1,4 @@
 {
-    "title": "Web Bluetooth",
-    "wgs": [
-        {
-            "url": "https://www.w3.org/community/web-bluetooth/",
-            "label": "Web Bluetooth Community Group"
-        }
-    ],
     "editors": "https://webbluetoothcg.github.io/web-bluetooth/",
     "impl": {
         "caniuse": "web-bluetooth",

--- a/data/webusb.json
+++ b/data/webusb.json
@@ -1,11 +1,4 @@
 {
-    "title": "WebUSB API",
-    "wgs": [
-        {
-            "url": "https://wicg.github.io/webusb/",
-            "label": "Web Platform Incubator Community Group"
-        }
-    ],
     "editors": "https://wicg.github.io/webusb/",
     "impl": {
         "chromestatus": 5651917954875392


### PR DESCRIPTION
Addresses #208.

The code now makes use of the `publisher` property returned by Specref to find a friendly label for the group that delivered the spec.

It also tries to set a `publisher` property, which is for now one of W3C, IETF or WHATWG. If that property is not already set, it looks at the URL of the group and at the URL of the spec to find out which organization published it.

Note I made a first pass at the data files to remove information that is no longer needed. Specref does not have all the specs we need to reference though (I'll try to prepare PR against Specref to add them)