### PR TITLE
[Framework] Complete impl info (prefix, flag, notes)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,13 +3,13 @@ all: specs/tr.json specs/impl.json
 DATA=$(wildcard data/*.json)
 
 specs/tr.json: $(DATA)
-	node tools/extract-spec-data.js $^ > $@
+	node tools/extract-spec-data.js data > $@
 
 specs/impl.json: $(DATA)
-	node tools/extract-impl-data.js $^ > $@
+	node tools/extract-impl-data.js data > $@
 
 check: $(DATA) $(wildcard */*.html)
 	python tools/validate-schema.py $(DATA)
-	node tools/extract-impl-data.js $(DATA) > /dev/null
-	node tools/extract-spec-data.js $(DATA) > /dev/null
+	node tools/extract-impl-data.js data > /dev/null
+	node tools/extract-spec-data.js data > /dev/null
 	html5validator --root .

--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ When this happens, you may use the `other` sub-property to specify implementatio
 * `source` (optional but recommended): a short name that identifies the origin of the information. Use `feedback` to flag information that comes from review and that should override whatever other implementation status the framework might be able to retrieve automatically for the user agent under consideration.
 * `date` (optional but recommended): the `YYYY-MM-DD` date at which that manually information was last reviewed. Keeping implementation information up to date, is difficult, and error prone. The information needs to be periodically checked and re-validated. The date is meant to track the last time when someone checked and validated the information.
 * `comment` (optional but recommended): a comment that provides contextual information, for instance to explain why the information in platform status sources should be regarded as incorrect.
+* `prefix` (optional): whether the implementation requires the use of a prefix
+* `flag` (optional): whether some flag needs to be set to enable the feature
 
 For instance, let's say that "Can I use" report that a particular feature is in development in Webkit, whereas you know that the feature has not yet been considered there; and that it does not report anything on status in Edge, whereas you know from discussion with the Edge team that it is being considered, you could add:
 
@@ -234,7 +236,7 @@ If you would like to visualize the contents of a roadmap locally as it would app
 
 1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done
 2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key
-3. Run the [Makefile](Makefile) to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
+3. Run `npm run all` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
 4. Serve the root folder of the repository over HTTP (any HTTP server should work). In particular, opening the file directly with your Web browser will not work because the JavaScript code needs to send cross origin requests, which are not supported for `file://` URLs.
 
 ## Translating a roadmap

--- a/compile.sh
+++ b/compile.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 set -e # Exit with nonzero exit code if anything fails
 
-node tools/extract-spec-data.js data/*.json > specs/tr.json
-node tools/extract-impl-data.js data/*.json > specs/impl.json
+node tools/extract-spec-data.js data > specs/tr.json
+node tools/extract-impl-data.js data > specs/impl.json
 
 if [ -d out ]; then
   rm -rf out/assets && cp -R assets/ out/assets/

--- a/data/ambientlight.json
+++ b/data/ambientlight.json
@@ -13,7 +13,7 @@
         "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
       },
       {
-        "ua": "and_ff",
+        "ua": "firefox_android",
         "status": "",
         "source": "feedback",
         "date": "2018-03-16",

--- a/data/proximity.json
+++ b/data/proximity.json
@@ -11,7 +11,7 @@
         "comment": "The version based on the Generic Sensor API is not what is shipping in Firefox, see https://github.com/w3c/web-roadmaps/issues/160"
       },
       {
-        "ua": "and_ff",
+        "ua": "firefox_android",
         "status": "",
         "source": "feedback",
         "date": "2018-03-19",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,8 @@
     "xpath": "0.0.27"
   },
   "scripts": {
-    "specinfo": "node tools/extract-spec-data.js data > specs/tr.json"
+    "all": "npm run specinfo && npm run implinfo",
+    "specinfo": "node tools/extract-spec-data.js data > specs/tr.json",
+    "implinfo": "node tools/extract-impl-data.js data > specs/impl.json"
   }
 }


### PR DESCRIPTION
This update completes the implementation info retrieved from Web platform status
sources:
- a `prefix` flag is set when the implementation requires a prefix
- a `flag` flag is set when the implementation is behind some sort of flag
- status is set to `experimental` instead of `shipped` whenever the `prefix` or `flag` flags are set
- a `notes` array contains implementation notes when available (the `comment` property in the data file gets mapped to that array)
- mobile browser names normalized in a more logical way, now follow the names used in mdn-browser-compat (preliminary work for #13)
- better support for Chrome implementation info, in particular on Android (preliminary work for #13)

This info is not yet being used by the Web application, so the update does not change much for now, except for:
- a couple of specs that were reported as shipped and that are now reported as "experimental", e.g. Web Crypto in Edge which still requires a prefix
- a couple of specs that were reported as shipped in Chrome and that are now no longer reported because implementation is actually in Chrome for Android (e.g. the Remote Playback API)

Note that MSE support in Chrome now seems wrong to me (experimental instead of shipped), but the thing is Chrome status reports that a prefix is still required:
https://www.chromestatus.com/features/4563797888991232