### PR TITLE
[Framework] Move filtering menus generation logic

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -250,10 +250,14 @@ Styles for the "current implementations" column
 
 /* UA filtering menu */
 [data-col|=impl] details {
+  display: none;
   position: relative;
-  display: block;
   padding: 0 0.1em;
   text-align: left;
+}
+
+[data-col|=impl] details.active {
+  display: block;
 }
 
 [data-col|=impl] summary {

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -894,7 +894,7 @@ const formatImplInfo = function (data, translate) {
       }
       let title = translate('labels', '%status in %ua (%versions).')
         .replace('%status', statusLabel)
-        .replace('%ua', impl.ua)
+        .replace('%ua', translate('browsers', impl.ua))
         .replace('%versions', versions.map(
           version => translate('labels', version)).join(', '));
       if (impl.prefix && impl.flag) {

--- a/js/generate.js
+++ b/js/generate.js
@@ -106,25 +106,24 @@ loadScript('../js/utils.js')
       loadToc(lang)
     ]);
   }).then(results => {
-    let translations = results[1];
+    let translate = results[1];
     let toc = results[2];
     return Promise.all([
-      applyToc(toc, translations, lang, pagetype),
-      setSectionTitles(translations, lang),
+      applyToc(toc, translate, lang, pagetype),
+      setSectionTitles(translate, lang),
       loadSpecInfo(),
       loadImplementationInfo(),
-      translations
+      translate
     ]);
   }).then(results => {
     let customTables = results[0]['tables'];
-    return fillTables(results[2], results[3], customTables, results[4], lang);
+    fillTables(results[2], results[3], customTables, results[4], lang);
+    addFilteringMenus(results[4]);
   }).then(_ => {
+    // Remove duplicate warnings and report them
+    warnings = warnings.filter((warning, idx, self) => self.indexOf(warning) === idx);
+    warnings.forEach(warning => console.warn(warning));
+
     document.documentElement.setAttribute('data-generated', '');
     document.dispatchEvent(new Event('generate'));
-
-    // Remove duplicate warnings and report them after filtering menu is ready
-    document.addEventListener('filter-uas', _ => {
-      warnings = warnings.filter((warning, idx, self) => self.indexOf(warning) === idx);
-      warnings.forEach(warning => console.warn(warning));
-    });
   });

--- a/js/translations.json
+++ b/js/translations.json
@@ -25,6 +25,8 @@
     "edge": "Microsoft Edge",
     "firefox": "Firefox",
     "safari|webkit": "Safari / Webkit",
+    "safari": "Safari",
+    "webkit": "Webkit",
     "baidu": "Baidu Browser",
     "opera": "Opera",
     "qq": "QQ Browser",

--- a/js/translations.zh.json
+++ b/js/translations.zh.json
@@ -19,6 +19,8 @@
     "edge": "Microsoft Edge",
     "firefox": "Firefox",
     "safari|webkit": "Safari / Webkit",
+    "safari": "Safari",
+    "webkit": "Webkit",
     "baidu": "百度浏览器",
     "opera": "Opera",
     "qq": "QQ浏览器",


### PR DESCRIPTION
Follow-up to PR #216 to [keep dependencies minimal in published snapshots](https://github.com/w3c/web-roadmaps/pull/216#issuecomment-381513338).

The filtering menus of the implementation column are now generated by the `generate.js` script. This means that the `filter-implstatus.js` script:
1. stays agnostic about browsers that it needs to filter. The script merely uses the info in the filtering menus and does not need to hardcode a precise list of browsers.
2. no longer needs to load translation files, which thus do not need to be kept around in published snapshots.

The `generate-utils.js` and `utils.js` scripts have been kept separated for now to ease review but they can be merged again afterwards.

The update also adds the possibility to provide translations of "desktop" and "mobile" in the tooltip.