### PR TITLE
[Framework] Fix Chrome Platform parsing, drop Opera for Android

### DIFF
--- a/tools/extract-impl-data.js
+++ b/tools/extract-impl-data.js
@@ -218,7 +218,7 @@ let sources = {
         ua = (ua === 'ff' ? 'firefox' : ua);
         if (info) {
           // Chromestatus has more detailed and forward-looking implementation
-          // info about Chrome (aslo, "in development" and "consideration" are
+          // info about Chrome (also, "in development" and "consideration" are
           // at the Chromium level and thus apply to Chrome for desktops and
           // Chrome for Android)
           let enabledOnAllPlatforms = (info.status === 'indevelopment') ||


### PR DESCRIPTION
The Chrome Platform Status data is forward-looking in the sense that features implemented in upcoming versions of the browser may be flagged as "shipped".

The data does not state which version is the "current" version. We take that info from Can I Use, and consider that the desktop and Android versions are always equal (they are usually released within 1-2 days of one another).

For Opera, the rule applied in the Chrome Platform Status data is that Opera vX is based on Chromium vX+13. That is true for Opera for Desktop and releases seem to be synchronized too, so the code assumes that the current version of Opera for Desktop is the current version of Chromium minus 13. That is not true for Opera for Android, and the data seems wrong here (see discussion in #13).

Actually Can I use data for Opera for Android and Opera Mini are actually quite outdated too, so we simply do not know which version of Opera for Android is the current one and which version of Chromium it is based on. The code no longer extracts implementation info for Opera for Android and Opera Mini as a result.