### PR TITLE
[Framework] A series of UI accessibility improvements

### DIFF
--- a/assets/css/roadmap.css
+++ b/assets/css/roadmap.css
@@ -187,6 +187,11 @@ filter: grayscale(1);*/
   color: #547190;
 }
 
+#side-nav nav ul li a:focus {
+  padding: 14px 0px 14px 9px;
+  border: 1px dashed #547190;
+}
+
 #side-nav nav ul li a .icon {
   width: 15%;
   display: flex;
@@ -370,7 +375,7 @@ footer {
 footer p {
     margin: 0px;
     padding: 20px 0px 20px 0px;
-    color: #A2B1C1;
+    color: #767676;
     font-size: 0.9em;
     text-align: center;
 }

--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -58,6 +58,7 @@ p.highlight {
 a {
   color: #0062af;
   text-decoration: none;
+  border-bottom: 1px solid #767676;
 }
 
 a:hover {
@@ -96,15 +97,6 @@ color: white;
 padding: 7px 15px 7px 15px;
 }
 
-a.btn {
-}
-
-a.btn-reverse {
-}
-
-.container {
-}
-
 .container-fluid {
     width: 100%;
 
@@ -132,7 +124,7 @@ th { font-weight: 800; }
 tbody th { text-align:left; }
 thead th {
     background-color: #0070cc;
-    color: #eee;
+    color: #f3f3f3;
     padding: 0.5em 0;
     vertical-align: top;
 }
@@ -142,7 +134,13 @@ th, td {
     padding-bottom: 0.5em;
 }
 tbody th, tbody td { padding-left: 0.5em;}
-th.feature { max-width: 150px; }
+th.feature {
+  max-width: 150px;
+}
+th.feature[rowspan] {
+  vertical-align: top;
+  padding-top: 1.5em;
+}
 td.maturity { text-align: center; }
 td.maturity img { vertical-align: middle; }
 td.impl { min-width: 220px; }
@@ -152,6 +150,15 @@ td ul {
     padding-left: 0;
     margin-top: -8px;
 }
+
+
+/************************************************************
+Remove link underlines in table and menu
+************************************************************/
+.brand a, #side-nav a, table a {
+  border-bottom: none;
+}
+
 
 
 /************************************************************

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -500,9 +500,7 @@ const applyToc = function (toc, translate, lang, pagetype) {
   if (toc.about) {
     pages.push({
       title: toc.about.title || translate('labels', 'About this document'),
-      url: ((lang === 'en') ?
-        toc.about.url :
-        toc.about.url.replace(/\.([^\.]+)$/, '.' + lang + '.$1')),
+      url: toc.about.url,
       icon: toc.about.icon || '../assets/img/about.svg'
     });
   }
@@ -510,7 +508,7 @@ const applyToc = function (toc, translate, lang, pagetype) {
     const localizedUrl = ((lang === 'en') ? page.url :
       page.url.replace(/\.([^\.]+)$/, '.' + lang + '.$1'));
 
-    if (mainNav) {
+    if (mainNav && (!toc.about || (page.url !== toc.about.url))) {
       let mainNavItem = document.createElement('li');
       mainNavItem.innerHTML = templateItem;
       mainNavItem.querySelector('a').href = localizedUrl;

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -1,20 +1,165 @@
 (function () {
-  var sideNav = document.getElementById('side-nav')
-  var sideNavBtn = document.getElementById('side-nav-btn')
-  var mask = document.getElementById('mask')
-  //var closeSideNavBtn = document.getElementById('close-side-nav-btn')
+  /**
+   * Wraps querySelectorAll to return an Array across browsers
+   */
+  const $ = (el, selector) =>
+    Array.prototype.slice.call(el.querySelectorAll(selector), 0);
 
-  sideNavBtn.addEventListener('click', function () {
-    mask.className += ' active'
-    sideNav.className += ' active'
-  })
+  // Key codes of key events we want to respond to in the menu
+  const keys = {
+    tab: 9,
+    pageup: 33,
+    pagedown: 34,
+    end: 35,
+    home: 36,
+    up: 38,
+    down: 40
+  };
 
-  /*closeSideNavBtn.addEventListener('click', function () {
-    mask.className = mask.className.replace('active', 'hidden')
-    sideNav.className = sideNav.className.replace('active', 'hidden')
-  })*/
-  mask.addEventListener('click', function () {
-    mask.className = mask.className.replace('active', 'hidden')
-    sideNav.className = sideNav.className.replace('active', 'hidden')
-  })
+  // Pointers to relevant elements in the DOM
+  const menu = document.getElementById('side-nav');
+  const mask = document.getElementById('mask');
+  const button = document.getElementById('side-nav-btn');
+  const buttonImg = button.querySelector('img');
+
+  // Alternative texts for the menu button
+  const actionLabels = {
+    open: buttonImg.getAttribute('alt'),
+    close: buttonImg.getAttribute('data-altclose')
+  };
+
+  // The list of links in the menu
+  const menuItems = $(menu, 'a');
+
+  // Pointer to the last element that had focus in the main part of the
+  // document. Focus will get back to that element when the menu is closed.
+  let lastActiveElement = null;
+
+  // Flag set when the side menu is in an open state.
+  let isMenuOpened = false;
+
+
+  /**
+   * Handles "keydown" event on individual menu items to navigate the menu
+   */
+  function handleMenuItemKeydown(evt) {
+    if (evt.altKey || evt.ctrlKey ||
+        (evt.shiftKey && (evt.keyCode != keys.tab))) {
+      return true;
+    }
+
+    let focusPosition = menuItems.indexOf(evt.target);
+    switch (evt.keyCode) {
+      case keys.tab:
+        if (evt.shiftKey) {
+          focusPosition -= 1;
+        }
+        else {
+          focusPosition += 1;
+        }
+        break;
+      case keys.down:
+        focusPosition += 1;
+        break;
+      case keys.up:
+        focusPosition -= 1;
+        break;
+      case keys.home:
+        focusPosition = 0;
+        break;
+      case keys.end:
+        focusPosition = menuItems.length - 1;
+        break;
+      case keys.pagedown:
+        focusPosition += 5;
+        break;
+      case keys.pageup:
+        focusPosition -= 5;
+        break;
+      default:
+        // Ignore other key codes
+        return true;
+    }
+
+    // Make focus wrap around menu items
+    if (focusPosition < 0) {
+      focusPosition = menuItems.length - 1;
+    }
+    if (focusPosition >= menuItems.length) {
+      focusPosition = 0;
+    }
+
+    // Focus the new menu item and prevent default action
+    menuItems[focusPosition].focus();
+    evt.stopPropagation();
+    evt.preventDefault();
+    return false;
+  }
+
+
+  /**
+   * For browsers that do something on "keypress" instead of on "keydown",
+   * prevent default action if we already reacted on "keydown"
+   */
+  function handleMenuItemKeypress(evt) {
+    if (evt.altKey || evt.ctrlKey ||
+        (evt.shiftKey && (evt.keyCode != keys.tab))) {
+      return true;
+    }
+    switch (evt.keyCode) {
+      case keys.tab:
+      case keys.down:
+      case keys.up:
+      case keys.home:
+      case keys.end:
+      case keys.pagedown:
+      case keys.pageup:
+        evt.stopPropagation();
+        evt.preventDefault();
+        return false;
+      default:
+        return true;
+    }
+  }
+
+
+  /**
+   * Toggle the menu
+   */
+  function toggleMenu() {
+    if (isMenuOpened) {
+      mask.className = mask.className.replace('active', 'hidden');
+      menu.className = menu.className.replace('active', 'hidden');
+      buttonImg.setAttribute('alt', actionLabels.open);
+      menuItems.forEach(item => {
+        item.setAttribute('tabindex', '-1');
+        item.blur();
+      });
+      if (lastActiveElement) {
+        lastActiveElement.focus();
+      }
+    }
+    else {
+      mask.className += ' active';
+      menu.className += ' active';
+      buttonImg.setAttribute('alt', actionLabels.close);
+      lastActiveElement = document.activeElement;
+      menuItems.forEach(item => item.setAttribute('tabindex', '0'));
+      menuItems[0].focus();
+    }
+    isMenuOpened = !isMenuOpened;
+  }
+
+  // React to user actions that toggle the menu
+  button.addEventListener('click', toggleMenu);
+  mask.addEventListener('click', toggleMenu);
+  document.addEventListener('keydown', function (evt) {
+    if ((evt.key === 'm') || (evt.key === 'M')) {
+      return toggleMenu();
+    }
+  });
+
+  // React to user navigation in the menu
+  menuItems.forEach(item => item.addEventListener('keydown', handleMenuItemKeydown));
+  menuItems.forEach(item => item.addEventListener('keypress', handleMenuItemKeypress));
 })()

--- a/js/template-page.html
+++ b/js/template-page.html
@@ -14,14 +14,13 @@
 
     <header>
       <div class="container">
-        <button id="side-nav-btn" type="button" name="sidenav-opener"><img src="../assets/img/menu.svg" height="15" alt=""></button>
-
-
-                <div class="brand">
-                  <a href="https://www.w3.org/"><img src="../assets/img/w3c.svg" height="30" alt="W3C"></a>
-                </div>
+        <button id="side-nav-btn" type="button" name="sidenav-opener">
+            <img src="../assets/img/menu.svg" height="15" alt="Open menu" data-altclose="Close menu" />
+        </button>
+        <div class="brand">
+          <a href="https://www.w3.org/"><img src="../assets/img/w3c.svg" height="30" alt="W3C"></a>
+        </div>
       </div>
-
     </header>
 
 

--- a/js/template-page.zh.html
+++ b/js/template-page.zh.html
@@ -15,7 +15,7 @@
     <header>
       <div class="container">
         <button id="side-nav-btn" type="button" name="sidenav-opener">
-          <img src="../assets/img/menu.svg" height="15" alt="Open menu" data-altclose="Close menu">
+          <img src="../assets/img/menu.svg" height="15" alt="打开菜单" data-altclose="关闭菜单">
         </button>
         <div class="brand">
           <a href="https://www.w3.org/"><img src="../assets/img/w3c.svg" height="30" alt="W3C"></a>

--- a/js/template-page.zh.html
+++ b/js/template-page.zh.html
@@ -14,14 +14,13 @@
 
     <header>
       <div class="container">
-        <button id="side-nav-btn" type="button" name="sidenav-opener"><img src="../assets/img/menu.svg" height="15" alt=""></button>
-
-
-                <div class="brand">
-                  <a href="https://www.w3.org/"><img src="../assets/img/w3c.svg" height="30" alt="W3C"></a>
-                </div>
+        <button id="side-nav-btn" type="button" name="sidenav-opener">
+          <img src="../assets/img/menu.svg" height="15" alt="Open menu" data-altclose="Close menu">
+        </button>
+        <div class="brand">
+          <a href="https://www.w3.org/"><img src="../assets/img/w3c.svg" height="30" alt="W3C"></a>
+        </div>
       </div>
-
     </header>
 
 


### PR DESCRIPTION
This update contains a short series to address main reported accessibility issues of the User Interface. Changes are:

- Links in text are underlined (#226)
- Menu is now keyboar accessible and "Tab/Up/Down/Home/End" key friendly (#227)
- Feature labels in tables are top-aligned when there the column spans multiple rows (#229)
- Menu button is correctly labelled (#230)
- Contrast of table headers improved (#231)
- Contrast of footer improved (#232)

Actually, the menu can now be opened and closed through the "m" key. I haven't tried to advertise that anywhere for now.

The update also fixes the URL of the about page in translations (#233)

@xfq I let you update the "alt" texts for the menu button in `template-page.zh.html`!