### PR TITLE
[Framework] Script to generate all roadmap pages automatically

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 deploy_key
 .cache
+.out
 node_modules
 config.json

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ It aims at simplifying the creation and maintenance of such roadmaps by collecti
 * [Creating the index of a new multi-page roadmap](#creating-the-index-of-a-new-multi-page-roadmap)
 * [Creating an About this document page](#creating-an-about-this-document-page))
 * [Repository branches](#repository-branches)
+* [Generate content locally](#generate-content-locally)
 * [Translating a roadmap](#translating-a-roadmap)
 
 ## Overview of the framework
@@ -298,12 +299,22 @@ The source of the roadmaps is in the `master` branch. This is the default branch
 
 The `gh-pages` branch is the branch published on [`https://w3c.github.io/web-roadmaps/`](https://w3c.github.io/web-roadmaps/).
 
+## Generate content locally
+
 If you would like to visualize the contents of a roadmap locally as it would appear on the published version, you will need to:
 
 1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done.
 2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key.
-3. Run `npm run all` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. It should also validate the data files, the generated files and the HTML files. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
-4. Serve the root folder of the repository over HTTP (any HTTP server should work). In particular, opening the file directly with your Web browser will not work because the JavaScript code needs to send cross origin requests, which are not supported for `file://` URLs.
+3. Run `npm run all` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. It should also validate the data files, the generated files and the HTML files. Last but not least, it should generate static versions of the roadmap pages in an `.out` folder. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
+4. Browse the contents of the `.out` folder on your favorite Web browser (opening the file works fine, no need to serve the file over HTTP).
+
+The `npm run all` script can take some time. If you want to have a more interactive way to browse updates you're making to files, you may follow these instructions instead:
+
+1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done.
+2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key.
+3. Run `npm run generate-info` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. This step needs to be run again whenever you make changes to information in the `data` folder.
+4. Serve the root folder over HTTP (any simple HTTP server should work), and browse the roadmap files over HTTP in your favorite Web browser. Refresh the content whenever you've made changes to the HTML, JS, or data files.
+
 
 ## Translating a roadmap
 

--- a/js/filter-implstatus.js
+++ b/js/filter-implstatus.js
@@ -24,9 +24,15 @@ See: https://github.com/javan/details-element-polyfill
 
 /*******************************************************************************
 Details Element Polyfill 2.0.1
+
+NB: the ugly heuristics are meant to identify JSDOM so as not to run the
+script in that context to avoid JSDOM reporting errors (script is not needed
+in JSDOM)
 *******************************************************************************/
 (function(){}).call(this),function(){
+if (!(window._runScripts && window._virtualConsole && (window.name === 'nodejs'))) {
   var t,e,n,r,u,o,i,a,l,s,c,d;s={element:function(){var t,e,n,r,u;return e=document.createElement("details"),"open"in e?(e.innerHTML="<summary>a</summary>b",e.setAttribute("style","position: absolute; left: -9999px"),r=null!=(u=document.body)?u:document.documentElement,r.appendChild(e),t=e.offsetHeight,e.open=!0,n=e.offsetHeight,r.removeChild(e),t!==n):!1}(),toggleEvent:function(){var t;return t=document.createElement("details"),"ontoggle"in t}()},s.element&&s.toggleEvent||(i=function(){return document.head.insertAdjacentHTML("afterbegin",'<style>@charset"UTF-8";details:not([open])>*:not(summary){display:none;}details>summary{display:block;}details>summary::before{content:"\u25ba";padding-right:0.3rem;font-size:0.6rem;cursor:default;}details[open]>summary::before{content:"\u25bc";}</style>')},o=function(){var t,e,n,r;return e=document.createElement("details").constructor.prototype,r=e.setAttribute,n=e.removeAttribute,t=Object.getOwnPropertyDescriptor(e,"open"),Object.defineProperties(e,{open:{get:function(){var e;return"DETAILS"===this.tagName?this.hasAttribute("open"):null!=t&&null!=(e=t.get)?e.call(this):void 0},set:function(e){var n;return"DETAILS"===this.tagName?(e?this.setAttribute("open",""):this.removeAttribute("open"),e):null!=t&&null!=(n=t.set)?n.call(this,e):void 0}},setAttribute:{value:function(t,e){return d(this,function(n){return function(){return r.call(n,t,e)}}(this))}},removeAttribute:{value:function(t){return d(this,function(e){return function(){return n.call(e,t)}}(this))}}})},a=function(){return r(function(t){var e;return e=t.querySelector("summary"),t.hasAttribute("open")?(t.removeAttribute("open"),e.setAttribute("aria-expanded",!1)):(t.setAttribute("open",""),e.setAttribute("aria-expanded",!0))})},u=function(){var e,n,r,u,o;for(u=document.querySelectorAll("summary"),e=0,n=u.length;n>e;e++)o=u[e],t(o);return"undefined"!=typeof MutationObserver&&null!==MutationObserver?(r=new MutationObserver(function(e){var n,r,u,i,a;for(i=[],r=0,u=e.length;u>r;r++)n=e[r].addedNodes,i.push(function(){var e,r,u;for(u=[],e=0,r=n.length;r>e;e++)a=n[e],"DETAILS"===a.tagName&&(o=a.querySelector("summary"))?u.push(t(o,a)):u.push(void 0);return u}());return i}),r.observe(document.documentElement,{subtree:!0,childList:!0})):document.addEventListener("DOMNodeInserted",function(e){return"SUMMARY"===e.target.tagName?t(e.target):void 0})},t=function(t,e){return null==e&&(e=n(t,"DETAILS")),t.setAttribute("aria-expanded",e.hasAttribute("open")),t.hasAttribute("tabindex")||t.setAttribute("tabindex","0"),t.hasAttribute("role")?void 0:t.setAttribute("role","button")},l=function(){var t;return"undefined"!=typeof MutationObserver&&null!==MutationObserver?(t=new MutationObserver(function(t){var e,n,r,u,o,i;for(o=[],n=0,r=t.length;r>n;n++)u=t[n],i=u.target,e=u.attributeName,"DETAILS"===i.tagName&&"open"===e?o.push(c(i)):o.push(void 0);return o}),t.observe(document.documentElement,{attributes:!0,subtree:!0})):r(function(t){var e;return e=t.getAttribute("open"),setTimeout(function(){return t.getAttribute("open")!==e?c(t):void 0},1)})},e=function(t){return!(t.defaultPrevented||t.altKey||t.ctrlKey||t.metaKey||t.shiftKey||t.target.isContentEditable)},r=function(t){return addEventListener("click",function(r){var u,o;return e(r)&&r.which<=1&&(u=n(r.target,"SUMMARY"))&&"DETAILS"===(null!=(o=u.parentElement)?o.tagName:void 0)?t(u.parentElement):void 0},!1),addEventListener("keydown",function(r){var u,o,i;return e(r)&&(13===(o=r.keyCode)||32===o)&&(u=n(r.target,"SUMMARY"))&&"DETAILS"===(null!=(i=u.parentElement)?i.tagName:void 0)?(t(u.parentElement),r.preventDefault()):void 0},!1)},n=function(){return"function"==typeof Element.prototype.closest?function(t,e){return t.closest(e)}:function(t,e){for(;t;){if(t.tagName===e)return t;t=t.parentElement}}}(),c=function(t){var e;return e=document.createEvent("Events"),e.initEvent("toggle",!0,!1),t.dispatchEvent(e)},d=function(t,e){var n,r;return n=t.getAttribute("open"),r=e(),t.getAttribute("open")!==n&&c(t),r},s.element||(i(),o(),a(),u()),s.element&&!s.toggleEvent&&l())
+}
 }.call(this);
 
 (function () {
@@ -86,7 +92,9 @@ Details Element Polyfill 2.0.1
     // Save the list of selected UA to the session storage
     // (not using persistent storage as default view seems preferable when
     // the user comes back to the page after some time)
-    window.sessionStorage.setItem('uas', uas.join('|'));
+    if (window.sessionStorage) {
+      window.sessionStorage.setItem('uas', uas.join('|'));
+    }
   };
 
   /**
@@ -125,7 +133,7 @@ Details Element Polyfill 2.0.1
 
     // Load requested user-agents from session storage if no specific
     // user-agents were provided in the query string
-    if (!uas && window.sessionStorage.getItem('uas')) {
+    if (!uas && window.sessionStorage && window.sessionStorage.getItem('uas')) {
       uas = window.sessionStorage.getItem('uas').split('|');
     }
 
@@ -168,5 +176,5 @@ Details Element Polyfill 2.0.1
   // in other words when the page is a published version of the generated page,
   // the "data-generated" attribute should already exist.
   document.addEventListener('generate', loadHandler);
-  document.addEventListener('load', loadHandler);
+  window.addEventListener('load', loadHandler);
 })();

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -544,22 +544,23 @@ const applyToc = function (toc, translate, lang, pagetype) {
         // that the index page in English may end with "/" instead of with
         // "/index.html"
         let url = null;
+        let filename = window.location.pathname.replace(/^.*\/([^\/]*)$/, '$1');
         if (lang === 'en') {
           // Current doc is in English, add the right lang to the current URL
-          if (!window.location.pathname.match(/\.([^\.]+)$/)) {
-            url = window.location.pathname + 'index.' + tr.lang + '.html';
+          if (!filename) {
+            url = 'index.' + tr.lang + '.html';
           }
           else {
-            url = window.location.pathname.replace(/\.([^\.]+)$/, '.' + tr.lang + '.$1');
+            url = filename.replace(/\.([^\.]+)$/, '.' + tr.lang + '.$1')
           }
         }
         else if (tr.lang === 'en') {
           // English version, remove the lang from the URL
-          url = window.location.pathname.replace(/\.([^\.]+)\.([^\.]+)$/, '.$2');
+          url = filename.replace(/\.([^\.]+)\.([^\.]+)$/, '.$2');
         }
         else {
           // Replace language in the current URL with the target language
-          url = window.location.pathname.replace(/\.([^\.]+)\.([^\.]+)$/, '.' + tr.lang + '.$2');
+          url = filename.replace(/\.([^\.]+)\.([^\.]+)$/, '.' + tr.lang + '.$2');
         }
         return '<a href="' + url + '" data-nav>' + tr.title + '</a>';
       }

--- a/package.json
+++ b/package.json
@@ -2,16 +2,21 @@
   "name": "web-roadmaps",
   "dependencies": {
     "ajv-cli": "^3.0.0",
-    "fetch-filecache-for-crawling": "^1.4.0"
+    "fetch-filecache-for-crawling": "^1.4.0",
+    "jsdom": "^11.8.0",
+    "mkdirp": "^0.5.1",
+    "ncp": "^2.0.0"
   },
   "scripts": {
-    "all": "npm run validate-data && npm run generate && npm run validate-specinfo && npm run validate-implinfo && npm run validate-html",
-    "generate": "npm run specinfo && npm run implinfo",
-    "specinfo": "node tools/extract-spec-data.js data > specs/tr.json",
-    "implinfo": "node tools/extract-impl-data.js data > specs/impl.json",
+    "all": "npm run validate-data && npm run generate-info && npm run validate-html && npm run validate-info && npm run generate-pages",
+    "generate-info": "npm run generate-specinfo && npm run generate-implinfo",
+    "generate-specinfo": "node tools/extract-spec-data.js data > specs/tr.json",
+    "generate-implinfo": "node tools/extract-impl-data.js data > specs/impl.json",
+    "generate-pages": "node tools/generate-roadmaps.js",
     "validate-data": "ajv -s tools/spec.jsons -d data/\\*.json --errors=text",
-    "validate-html": "node tools/validate-html.js media mobile publishing security web5g",
+    "validate-info": "npm run validate-specinfo && npm run validate-implinfo",
     "validate-specinfo": "ajv -s tools/tr.jsons -d specs/tr.json --errors=text",
-    "validate-implinfo": "ajv -s tools/impl.jsons -d specs/impl.json --errors=text"
+    "validate-implinfo": "ajv -s tools/impl.jsons -d specs/impl.json --errors=text",
+    "validate-html": "node tools/validate-html.js media mobile publishing security web5g"
   }
 }

--- a/tools/generate-roadmaps.js
+++ b/tools/generate-roadmaps.js
@@ -1,0 +1,136 @@
+/*******************************************************************************
+Generates roadmaps in the repository to the '.out' folder
+
+To generate roadmaps:
+node tools/generate-roadmaps.js
+*******************************************************************************/
+
+const jsdom = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+const mkdirp = require('mkdirp');
+const ncp = require('ncp').ncp;
+
+
+/**
+ * Generate a roadmap page and save the result to the output folder
+ *
+ * @param  {String} file The roadmap page to generate
+ * @param  {String} outputFolder The output folder
+ * @return {Promise<Array(String)>} Promise to have generated the roadmap page
+ *   and to get a log of generation info
+ */
+async function generatePage(file, outputFolder) {
+  return new Promise(async (resolve, reject) => {
+    let logs = [];
+    logs.push(`- generate ${file}...`);
+
+    // Collect console messages as logs
+    const virtualConsole = new jsdom.VirtualConsole();
+    virtualConsole.on('error', (...args) => args.map(msg => logs.push(msg)));
+    virtualConsole.on('warn', (...args) => args.map(msg => logs.push(msg)));
+    virtualConsole.on('info', (...args) => args.map(msg => logs.push(msg)));
+    virtualConsole.on('dir', (...args) => args.map(msg => logs.push(msg)));
+
+    // Load the page using JSDOM
+    let dom = await jsdom.JSDOM.fromFile(file, {
+      runScripts: 'dangerously',
+      resources: 'usable',
+      virtualConsole
+    });
+    let doc = dom.window.document;
+
+    // Save the page once it has been generated
+    doc.addEventListener('generate', _ => {
+      doc.querySelectorAll('head script').forEach(
+        script => script.parentNode.removeChild(script));
+      let outputFile = path.join(outputFolder, file);
+      mkdirp(path.dirname(outputFile));
+      fs.writeFile(outputFile, dom.serialize(), 'utf-8', err => {        
+        if (err) {
+          console.error(`- generate ${file}... an error occurred`);
+          return reject(err);
+        }
+        logs.push(`- generate ${file}... done`);
+        return resolve(logs);
+      });
+    });
+  });
+}
+
+
+/**
+ * Copy the contents of a folder recursively
+ *
+ * Note some hardcoded rules to only copy the "right" files.
+ *
+ * @param  {[type]} folder [description]
+ * @param  {[type]} output [description]
+ * @return {[type]}        [description]
+ */
+function copyFolder(folder, output) {
+  return new Promise((resolve, reject) => {
+    ncp(folder, output, {
+      filter: file => {
+        let filename = path.basename(file);
+        if (folder === 'js') {
+          return (filename === 'js') ||
+            (filename === 'filter-implstatus.js') ||
+            (filename === 'sidenav.js');
+        }
+        else {
+          return !filename.startsWith('.');
+        }
+      }
+    }, err => {
+      if (err) {
+        reject(err);
+      }
+      else {
+        resolve();
+      }
+    });
+  });
+}
+
+
+
+/*******************************************************************************
+Main loop
+*******************************************************************************/
+// Put generated roadmap pages in the '.out' folder
+const outputFolder = '.out';
+try {
+  let stat = fs.statSync(outputFolder);
+}
+catch (err) {
+  mkdirp(outputFolder, err => {
+    if (err) {
+      console.error('Output folder does not exist and could not be created.');
+      process.exit(1);
+    }
+  });
+}
+
+// Compute the list of roadmap pages that need to be generated
+const inputFolders = fs.readdirSync('.')
+  .filter(f => fs.statSync(f).isDirectory())
+  .filter(f => !f.startsWith('.'))
+  .filter(f => !['assets', 'data', 'js', 'node_modules', 'specs', 'tools'].includes(f));
+const files = inputFolders.map(folder => {
+  return fs.readdirSync(folder)
+    .filter(f => f.endsWith('.html'))
+    .map(f => path.join(folder, f));
+}).reduce((res, files) => res.concat(files), []);
+
+// Generate all roadmap pages, and copy other files to the output folder
+Promise.all(files.map(file => generatePage(file, outputFolder)
+    .then(log => log.forEach(msg => console.log(msg)))
+  ))
+  .then(_ => copyFolder('assets', path.join(outputFolder, 'assets')))
+  .then(_ => copyFolder('js', path.join(outputFolder, 'js')))
+  .then(_ => copyFolder('specs', path.join(outputFolder, 'specs')))
+  .catch(err => {
+    console.error(err);
+    process.exit(2);
+  });


### PR DESCRIPTION
This update adds a script that generates all roadmap pages to a `.out` folder and copies relevant assets there as well. Addresses #129 (and part of #228 in the sense that we'll be able to replace the `gh-pages` branch with the generated pages).

Under the hoods, the script uses JSDOM to load HTML pages, run the generation in individual pages, and save the generated HTML content.

Some bits of code were adjusted accordingly not to create absolute URLs for translation links, and to respond to the right "load" event in generated documents.

What would still need to be done to complete this update:
1. use that mechanism to create the `gh-pages` branch in the Travis CI script
2. stop producing `tr.json` and `impl.json` in the `specs` folder. They should now directly be generated in the `.out` folder. These files are not needed in the generated pages, but I believe it's still a good idea to publish them somewhere.