### PR TITLE
[Framework] Deploy fully generated pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,14 +305,14 @@ If you would like to visualize the contents of a roadmap locally as it would app
 
 1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done.
 2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key.
-3. Run `npm run all` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. It should also validate the data files, the generated files and the HTML files. Last but not least, it should generate static versions of the roadmap pages in an `.out` folder. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
+3. Run `npm run all` to update information and implementation data. This should generate `.out/data/tr.json` and `.out/data/impl.json` files. It should also validate the data files, the generated files and the HTML files. Last but not least, it should generate static versions of the roadmap pages in an `.out` folder. Note you'll need Node.js v8.0.0 or above and you'll need to run `npm install` first.
 4. Browse the contents of the `.out` folder on your favorite Web browser (opening the file works fine, no need to serve the file over HTTP).
 
 The `npm run all` script can take some time. If you want to have a more interactive way to browse updates you're making to files, you may follow these instructions instead:
 
 1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done.
 2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key.
-3. Run `npm run generate-info` to update information and implementation data. This should generate `specs/tr.json` and `specs/impl.json` files. This step needs to be run again whenever you make changes to information in the `data` folder.
+3. Run `npm run generate-info` to update information and implementation data. This should generate `.out/data/tr.json` and `.out/data/impl.json` files. This step needs to be run again whenever you make changes to information in the `data` folder.
 4. Serve the root folder over HTTP (any simple HTTP server should work), and browse the roadmap files over HTTP in your favorite Web browser. Refresh the content whenever you've made changes to the HTML, JS, or data files.
 
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,18 +1,15 @@
 #!/bin/bash
 set -e # Exit with nonzero exit code if anything fails
 
+# Start from a fresh ".out" folder to avoid keeping files
+# that should be removed
+if [ -d .out ]; then
+  rm -rf .out
+fi
+
+# Generate the roadmaps, which should populate the ".out" folder
+# with all the files that need to be published
 npm run all
 
-if [ -d out ]; then
-  rm -rf out/assets && cp -R assets/ out/assets/
-  rm -rf out/data && cp -R data/ out/data/
-  rm -rf out/js && cp -R js/ out/js/
-  rm -rf out/media && cp -R media/ out/media/
-  rm -rf out/mobile && cp -R mobile/ out/mobile/
-  rm -rf out/publishing && cp -R publishing/ out/publishing/
-  rm -rf out/security && cp -R security/ out/security/
-  rm -rf out/web5g && cp -R web5g/ out/web5g/
-  cp specs/tr.json out/specs/tr.json
-  cp specs/impl.json out/specs/impl.json
-  cp README.md out/README.md
-fi
+# Copy the README over, because we want to publish the latest version as well
+cp README.md .out/README.md

--- a/deploy.sh
+++ b/deploy.sh
@@ -23,22 +23,22 @@ REPO=`git config remote.origin.url`
 SSH_REPO=${REPO/https:\/\/github.com\//git@github.com:}
 SHA=`git rev-parse --verify HEAD`
 
-# Clone the existing gh-pages for this repo into out/
+# Clone the existing gh-pages for this repo into .out/
 # Create a new empty branch if gh-pages doesn't exist yet (should only happen on first deply)
-git clone $REPO out
-cd out
+git clone $REPO .out
+cd .out
 git checkout $TARGET_BRANCH || git checkout --orphan $TARGET_BRANCH
 cd ..
 
 # Clean out existing contents
-# rm -rf out/* || exit 0
-rm -rf out/**/* || exit 0
+# rm -rf .out/* || exit 0
+rm -rf .out/**/* || exit 0
 
 # Run our compile script
 doCompile
 
 # Now let's go have some fun with the cloned repo
-cd out
+cd .out
 git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -648,7 +648,7 @@ const loadToc = function (lang) {
  * Loads known metadata for each specification
  */
 const loadSpecInfo = function () {
-  return loadUrl('../specs/tr.json')
+  return loadUrl('../.out/data/tr.json')
     .then(response => JSON.parse(response));
 };
 
@@ -657,7 +657,7 @@ const loadSpecInfo = function () {
  * Loads known implementation data for each specification
  */
 const loadImplementationInfo = function () {
-  return loadUrl('../specs/impl.json')
+  return loadUrl('../.out/data/impl.json')
     .then(response => JSON.parse(response));
 };
 

--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "all": "npm run validate-data && npm run generate-info && npm run validate-html && npm run validate-info && npm run generate-pages",
     "generate-info": "npm run generate-specinfo && npm run generate-implinfo",
-    "generate-specinfo": "node tools/extract-spec-data.js data > specs/tr.json",
-    "generate-implinfo": "node tools/extract-impl-data.js data > specs/impl.json",
+    "generate-specinfo": "mkdirp .out/data && node tools/extract-spec-data.js data > .out/data/tr.json",
+    "generate-implinfo": "mkdirp .out/data && node tools/extract-impl-data.js data > .out/data/impl.json",
     "generate-pages": "node tools/generate-roadmaps.js",
     "validate-data": "ajv -s tools/spec.jsons -d data/\\*.json --errors=text",
     "validate-info": "npm run validate-specinfo && npm run validate-implinfo",


### PR DESCRIPTION
Fix for #129.

The pages published on GitHub so far were the semi-generated pages: the feature info and implementation info were generated after each push but the pages were assembled on the client device.

With this update, pages in the `gh-pages` branch become the fully generated pages, meaning pages that have already been assembled and that are mostly static, except for a couple of scripts (one to handle the menu and one to implement the browser filtering mechanism).

The update fixes the flickering issue (#228) in published pages (technically, that problem still exists in page authoring mode, but that seems acceptable).