### PR TITLE
[Mobile] Add a changelog since previous snapshot

### DIFF
--- a/assets/css/theme.css
+++ b/assets/css/theme.css
@@ -51,6 +51,10 @@ p {
   color: #333;
 }
 
+li {
+  color: #333;
+}
+
 p.highlight {
   color: #00C853;
 }
@@ -299,7 +303,12 @@ Styles for the "current implementations" column
   margin: 0.6em;
 }
 
-dl dt { margin-bottom: 0.3em;  font-size:1.1em;}
+dl dt {
+  margin-bottom: 0.3em;
+  font-size: 1.1em;
+  font-weight: bold;
+
+}
 dl dd{ margin-bottom: 1em;}
 
 

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -614,8 +614,10 @@ const applyToc = function (toc, translate, lang, pagetype) {
     document.getElementById('side-nav-btn').hidden = true;
   }
 
+  // Fill out document metadata section
   fillDocumentMetadata(toc, translate, pagetype);
 
+  // Fill out the main menu (in the index page) and the side menu
   let mainNav = document.querySelector('ul.roadmap-list');
   let sideNav = document.querySelector('aside nav ul');
   let pages = pagetype.menu ? [] : [{
@@ -655,6 +657,24 @@ const applyToc = function (toc, translate, lang, pagetype) {
     }
   });
 
+  // Update links to other roadmap pages as needed
+  $(document, '[data-page]').map(el => {
+    let ref = el.getAttribute('data-page');
+    let page = toc.pages.find(p => p.url.startsWith(ref));
+    if (!page) {
+      console.warn('Referenced roadmap page does not exist: ' + ref);
+      return;
+    }
+
+    const localizedUrl = ((lang === 'en') ? page.url :
+      page.url.replace(/\.([^\.]+)$/, '.' + lang + '.$1'));
+    el.setAttribute('href', localizedUrl);
+    if (!el.textContent) {
+      el.textContent = page.title;
+    }
+  });
+
+  // Fill out the list of translations
   let listOfTranslations = toc.translations || [];
   if (listOfTranslations.length <= 1) {
     $(document, '.translations-wrapper').forEach(el => el.parentNode.removeChild(el));

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -8,7 +8,66 @@
     <header>
       <h1>About this document</h1>
     </header>
-    <main data-contents="about"></main>
+      <header>
+      <h1></h1>
+      <p>This roadmap is published and maintained by W3C Team. The <a href="https://w3c.github.io/web-roadmaps/mobile/">Editor's Draft of this document</a> is edited continuously based on progress of standardization discussions at W3C and elsewhere, and on feedback received on the <a href="https://github.com/w3c/web-roadmaps">GitHub repository</a>. Snapshots of this roadmap are published every few months. This page summarizes changes made between snapshots.</p>
+    </header>
+    <main data-contents="about">
+      <section>
+        <h2>Change History</h2>
+        <section>
+          <h3>April 2018</h3>
+          <p>The <a href="https://www.w3.org/2018/04/web-roadmaps/mobile/">April 2018</a> snapshot introduces a number of features that were missing from the <a href="https://www.w3.org/2018/01/web-roadmaps/mobile/">January 2018</a> snapshot. Content-wise, the following changes were made:</p>
+          <dl>
+            <dt>Exploratory work</dt>
+            <dd><ul>
+              <li>Mention the Web Share API and the Web Share Target API in <a data-page="lifecycle"></a> (#178)</li>
+              <li>Mention Requesting/Revoking permissions specifications in <a data-page="security"></a> (#180)</li>
+              <li>Mention Feature Policy in <a data-page="security"></a> (#180)</li>
+              <li>Mention Element Queries in <a data-page="adaptation"></a> (#195)</li>
+              <li>Replace WebVR by WebXR and mention polyfill in <a data-page="media"></a> (#199 and #204)</li>
+            </ul></dd>
+
+            <dt>Technologies in progress</dt>
+            <dd><ul>
+              <li>Fix Proximity sensor implementation status in <a data-page="sensors"></a> (#192)</li>
+              <li>Fix Ambient light API implementation status in Firefox and Edge in <a data-page="sensors"></a> (#186)</li>
+              <li>Fix Presentation API implementation status in Webkit in <a data-page="media"></a> (#182)</li>
+              <li>Mention the CSS <code>font-display</code> property and update text on downloadable fonts in <a data-page="graphics"></a> (#196)</li>
+              <li>Mention the Streams specification in <a data-page="network"></a> (#198)</li>
+            </ul></dd>
+
+            <dt>Well-deployed technologies</dt>
+            <dd><ul>
+              <li>Mention the CSS <code>box-sizing</code> property in <a data-page="graphics"></a> (#179)</li>
+              <li>Move <code>requestIdleCallback</code> to the Well-deployed section in <a data-page="performance"></a> (#190)</li>
+              <li>Update text on WOFF (WOFF 2.0 was recently published as a W3C Recommendation), mention variable fonts in <a data-page="graphics"></a> (#194)</li>
+              <li>Refine accessibility part in <a data-page="userinput"></a> and rename the category to promote accessibility (#201)</li>
+              <li>Mention the passive flag for event listeners in <a data-page="performance"></a> (#236)</li>
+            </ul></dd>
+
+            <dt>Discontinued features</dt>
+            <dd><ul>
+              <li>Mark humidity, thermometer, barometer proposals as discontinued in <a data-page="sensors"></a> (#187)</li>
+              <li>Mark appcache as discontinued in <a data-page="lifecycle"></a> (#193)</li>
+            </ul></dd>
+          </dl>
+
+          <p>The implementation info rendered in tables at the end of each section now embeds information about mobile browsers, and warns when a prefix is required or when a flag must be set to use a feature. Such features are also now consistently flagged as "Experimental" throughout the tables. Implementation information about additional browsers (Baidu, Opera, QQ, Samsung Internet, UC Web) can now be displayed from a dropdown menu. By default, tables will only display information about main browsers (Chrome, Microsoft Edge, Firefox, Safari), because this information is more up-to-date and reliable (information for other browsers may still be outdated or incorrect in some cases).</p>
+
+          <p>This version also features a series of User Interface improvements to improve the readability and accessibility of the pages.</p>
+
+          <p>Under the hoods, the roadmap framework has been almost entirely re-written to ease Roadmap authoring, and the publication of future snapshots. For instance, the extraction of information about W3C, WHATWG, and IETF specifications should now be automatic in most cases. Please refer to the <a href="https://github.com/w3c/web-roadmaps#framework-for-web-technology-roadmaps">documentation</a> for details.</p>
+        </section>
+
+        <section>
+          <h3>January 2018</h3>
+          <p>The <a href="https://www.w3.org/2018/01/web-roadmaps/mobile/">January 2018</a> snapshot is a major overhaul of the <a href="https://www.w3.org/2015/08/mobile-web-app-state/">previous mobile roadmap</a>, published until August 2015. Categories have remained vastly intact, but the new version comes with a new lightweight design, and the contents of the pages have been significantly updated to follow the evolution of the Web platform in the past few years.</p>
+          <p>The roadmap is published in <a href="https://www.w3.org/Mobile/roadmap/index.html">English</a> and <a href="https://www.w3.org/Mobile/roadmap/index.zh.html">Chinese</a>.</p>
+          <p>Some content may still be missing or incomplete. Among other things, implementation information only targets desktop browsers and is known not to be perfectly correct.</p>
+        </section>
+      </section>
+    </main>
     <script src="../js/generate.js"></script>
   </body>
 </html>


### PR DESCRIPTION
Add a changes since previous published version to the About page that highlights the list of updates in different sections, and quickly explains other changes made to the UI and underlying framework.

This update also introduces a generic way to link to roadmap pages with a `data-page` attribute whose value must be the URL of the page as it appears in the `toc.json` file (without the extension). The framework updates these links automatically, targeting the localized version when needed.

I did not try to link to GitHub issues and pull requests because that seems too "techy" for casual readers. It could perhaps have been useful to provide more details as to why a particular feature was added but the link to the roadmap page should hopefully provide the incentive to read it!

Note the change page may need further adjustments before we release the April snapshot.