### PR TITLE
[Framework] Add last modified dates to footer

### DIFF
--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -752,6 +752,39 @@ const applyToc = function (toc, translate, lang, pagetype) {
     $(document, '.translations').forEach(el => el.innerHTML = trtext.join (' | '));
   }
 
+  // Add document's last modified dates to footer
+  // We'll consider that document.lastModified represents the date when the
+  // content of the page was last updated, and that the current date represents
+  // the last date when the implementation data was updated. This is not
+  // perfect but these assumptions should remain reasonable.
+  // As an exception to the rule, we'll use the publishDate if it is set.
+  let queryString = window.location.search;
+  let publishDate = null;
+  if (queryString && queryString.startsWith('?')) {
+    queryString = queryString.slice(1).split('&');
+    queryString = queryString.forEach(paramvalue => {
+      let tokens = paramvalue.split('=');
+      if (tokens[0] === 'publishDate') {
+        publishDate = tokens[1];
+      }
+    });
+  }
+  publishDate = publishDate || toc.publishDate;
+  if (publishDate) {
+    publishDate = new Date(publishDate);
+  }
+
+  let lastModified = new Date(document.lastModified);
+  if (publishDate && (publishDate < lastModified)) {
+    lastModified = publishDate;
+  }
+  document.querySelector('[data-content-lastmodified]').textContent =
+    lastModified.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+
+  lastModified = publishDate || new Date();
+  document.querySelector('[data-impl-lastmodified]').textContent =
+    lastModified.toLocaleDateString('en-US', { month: 'long', year: 'numeric' });
+
   return toc;
 };
 

--- a/js/template-page.html
+++ b/js/template-page.html
@@ -64,13 +64,14 @@
             <div class="container">
                 <p>
                     <span class="translations-wrapper">Translations: <span class="translations"></span><br/></span>
-                    © <a href="https://www.w3.org/">W3C</a>
-                    <br>
-                    <a href="https://www.csail.mit.edu/">MIT</a> · <a href="https://www.ercim.eu/">ERCIM</a> · <a href="https://www.keio.ac.jp/">Keio</a> · <a href="http://ev.buaa.edu.cn/">Beihang</a>
+                    Content last updated in <span data-content-lastmodified></span><br/>
+                    © <a href="https://www.w3.org/">W3C</a> (<a href="https://www.csail.mit.edu/">MIT</a> · <a href="https://www.ercim.eu/">ERCIM</a> · <a href="https://www.keio.ac.jp/">Keio</a> · <a href="http://ev.buaa.edu.cn/">Beihang</a>)
                     <br>
                     Usage policies apply
                 </p>
-                <p>Information on implementations of the APIs have been gathered from <a href="http://caniuse.com/">Can I use?</a>, <a href="https://www.chromestatus.com/features">Chrome Platform Status</a>, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">Microsoft Edge web platform features status and roadmap</a>, <a href="https://webkit.org/status/">WebKit Feature Status</a>
+                <p>
+                    Information about features (maturity, implementations) have been gathered from the <a href="https://w3c.github.io/w3c-api/">W3C API</a>, <a href="https://www.specref.org/">Specref</a>, <a href="http://caniuse.com/">Can I use?</a>, <a href="https://www.chromestatus.com/features">Chrome Platform Status</a>, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">Microsoft Edge web platform features status and roadmap</a>, <a href="https://webkit.org/status/">WebKit Feature Status</a> in <span data-impl-lastmodified></span>
+                </p>
             </div>
         </footer>
     </body>

--- a/js/template-page.zh.html
+++ b/js/template-page.zh.html
@@ -64,16 +64,15 @@
             <div class="container">
                 <p>
                     <span class="translations-wrapper">语言: <span class="translations"></span><br/></span>
-                    © <a href="https://www.w3.org/">W3C</a>
-                    <br>
-                    <a href="https://www.csail.mit.edu/">MIT</a> · <a href="https://www.ercim.eu/">ERCIM</a> · <a href="https://www.keio.ac.jp/">Keio</a> · <a href="http://ev.buaa.edu.cn/">Beihang</a>
+                    Content last updated in <span data-content-lastmodified></span><br/>
+                    © <a href="https://www.w3.org/">W3C</a> (<a href="https://www.csail.mit.edu/">MIT</a> · <a href="https://www.ercim.eu/">ERCIM</a> · <a href="https://www.keio.ac.jp/">Keio</a> · <a href="http://ev.buaa.edu.cn/">Beihang</a>)
                     <br>
                     Usage policies apply
                 </p>
                 <p>
                   感谢蒋坤、李安琪、屈曦明、肖俊青和薛富侨提供中文翻译
                   <br>
-                  有关 API 实现的信息收集自 <a href="http://caniuse.com/">Can I use?</a>, <a href="https://www.chromestatus.com/features">Chrome Platform Status</a>, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">Microsoft Edge web platform features status and roadmap</a>, <a href="https://webkit.org/status/">WebKit Feature Status</a>
+                  有关 API 实现的信息收集自 <a href="http://caniuse.com/">Can I use?</a>, <a href="https://www.chromestatus.com/features">Chrome Platform Status</a>, <a href="https://developer.microsoft.com/en-us/microsoft-edge/platform/status/">Microsoft Edge web platform features status and roadmap</a>, <a href="https://webkit.org/status/">WebKit Feature Status</a> in <span data-impl-lastmodified></span>
                 </p>
             </div>
         </footer>


### PR DESCRIPTION
See #72. Two dates are being mentioned in the footer:
1. The date when the content iself was last updated. The assumption is that the last modified date of the document will be the correct date.
2. The date when the implementation data (and spec info) was last updated. The assumption is that this is the current date at the time when the page is generated.

As an exception to the rule, if `publishDate` is specified, then it is used (except for the content if it is more recent than `document.lastModified`)

The dates are not perfect. Also, having two dates is probably a bit confusing. But then both dates seem to make sense, and could be useful, especially on roadmap pages published on GitHub (e.g. to point out that content may be 6 months old, but implementation data is still "current").

@xfq I slightly updated the footer in the HTML template. Note I also updated the text about the "implementation data" in the English version, which still needs to be done in the Chinese version.