### PR TITLE
[Framework] Detect JSDOM in User-Agent string

### DIFF
--- a/js/filter-implstatus.js
+++ b/js/filter-implstatus.js
@@ -30,7 +30,7 @@ script in that context to avoid JSDOM reporting errors (script is not needed
 in JSDOM)
 *******************************************************************************/
 (function(){}).call(this),function(){
-if (!(window._runScripts && window._virtualConsole && (window.name === 'nodejs'))) {
+if (window.navigator.userAgent.split(/[\s\/]/).indexOf('jsdom') === -1) {
   var t,e,n,r,u,o,i,a,l,s,c,d;s={element:function(){var t,e,n,r,u;return e=document.createElement("details"),"open"in e?(e.innerHTML="<summary>a</summary>b",e.setAttribute("style","position: absolute; left: -9999px"),r=null!=(u=document.body)?u:document.documentElement,r.appendChild(e),t=e.offsetHeight,e.open=!0,n=e.offsetHeight,r.removeChild(e),t!==n):!1}(),toggleEvent:function(){var t;return t=document.createElement("details"),"ontoggle"in t}()},s.element&&s.toggleEvent||(i=function(){return document.head.insertAdjacentHTML("afterbegin",'<style>@charset"UTF-8";details:not([open])>*:not(summary){display:none;}details>summary{display:block;}details>summary::before{content:"\u25ba";padding-right:0.3rem;font-size:0.6rem;cursor:default;}details[open]>summary::before{content:"\u25bc";}</style>')},o=function(){var t,e,n,r;return e=document.createElement("details").constructor.prototype,r=e.setAttribute,n=e.removeAttribute,t=Object.getOwnPropertyDescriptor(e,"open"),Object.defineProperties(e,{open:{get:function(){var e;return"DETAILS"===this.tagName?this.hasAttribute("open"):null!=t&&null!=(e=t.get)?e.call(this):void 0},set:function(e){var n;return"DETAILS"===this.tagName?(e?this.setAttribute("open",""):this.removeAttribute("open"),e):null!=t&&null!=(n=t.set)?n.call(this,e):void 0}},setAttribute:{value:function(t,e){return d(this,function(n){return function(){return r.call(n,t,e)}}(this))}},removeAttribute:{value:function(t){return d(this,function(e){return function(){return n.call(e,t)}}(this))}}})},a=function(){return r(function(t){var e;return e=t.querySelector("summary"),t.hasAttribute("open")?(t.removeAttribute("open"),e.setAttribute("aria-expanded",!1)):(t.setAttribute("open",""),e.setAttribute("aria-expanded",!0))})},u=function(){var e,n,r,u,o;for(u=document.querySelectorAll("summary"),e=0,n=u.length;n>e;e++)o=u[e],t(o);return"undefined"!=typeof MutationObserver&&null!==MutationObserver?(r=new MutationObserver(function(e){var n,r,u,i,a;for(i=[],r=0,u=e.length;u>r;r++)n=e[r].addedNodes,i.push(function(){var e,r,u;for(u=[],e=0,r=n.length;r>e;e++)a=n[e],"DETAILS"===a.tagName&&(o=a.querySelector("summary"))?u.push(t(o,a)):u.push(void 0);return u}());return i}),r.observe(document.documentElement,{subtree:!0,childList:!0})):document.addEventListener("DOMNodeInserted",function(e){return"SUMMARY"===e.target.tagName?t(e.target):void 0})},t=function(t,e){return null==e&&(e=n(t,"DETAILS")),t.setAttribute("aria-expanded",e.hasAttribute("open")),t.hasAttribute("tabindex")||t.setAttribute("tabindex","0"),t.hasAttribute("role")?void 0:t.setAttribute("role","button")},l=function(){var t;return"undefined"!=typeof MutationObserver&&null!==MutationObserver?(t=new MutationObserver(function(t){var e,n,r,u,o,i;for(o=[],n=0,r=t.length;r>n;n++)u=t[n],i=u.target,e=u.attributeName,"DETAILS"===i.tagName&&"open"===e?o.push(c(i)):o.push(void 0);return o}),t.observe(document.documentElement,{attributes:!0,subtree:!0})):r(function(t){var e;return e=t.getAttribute("open"),setTimeout(function(){return t.getAttribute("open")!==e?c(t):void 0},1)})},e=function(t){return!(t.defaultPrevented||t.altKey||t.ctrlKey||t.metaKey||t.shiftKey||t.target.isContentEditable)},r=function(t){return addEventListener("click",function(r){var u,o;return e(r)&&r.which<=1&&(u=n(r.target,"SUMMARY"))&&"DETAILS"===(null!=(o=u.parentElement)?o.tagName:void 0)?t(u.parentElement):void 0},!1),addEventListener("keydown",function(r){var u,o,i;return e(r)&&(13===(o=r.keyCode)||32===o)&&(u=n(r.target,"SUMMARY"))&&"DETAILS"===(null!=(i=u.parentElement)?i.tagName:void 0)?(t(u.parentElement),r.preventDefault()):void 0},!1)},n=function(){return"function"==typeof Element.prototype.closest?function(t,e){return t.closest(e)}:function(t,e){for(;t;){if(t.tagName===e)return t;t=t.parentElement}}}(),c=function(t){var e;return e=document.createEvent("Events"),e.initEvent("toggle",!0,!1),t.dispatchEvent(e)},d=function(t,e){var n,r;return n=t.getAttribute("open"),r=e(),t.getAttribute("open")!==n&&c(t),r},s.element||(i(),o(),a(),u()),s.element&&!s.toggleEvent&&l())
 }
 }.call(this);
@@ -61,7 +61,7 @@ if (!(window._runScripts && window._virtualConsole && (window.name === 'nodejs')
 
     // Hide UA implementations that are not requested
     $(document, '[data-ua]')
-      .filter(el => !uas.includes(el.getAttribute('data-ua')))
+      .filter(el => uas.indexOf(el.getAttribute('data-ua')) === -1)
       .forEach(el => { el.hidden = true; el.style.display = 'none'; });
 
     // Hide wrapping label if there are no more visible implementation status
@@ -106,7 +106,7 @@ if (!(window._runScripts && window._virtualConsole && (window.name === 'nodejs')
   const updateFilteringMenus = function (uas) {
     // Update all menus in the page accordingly
     $(document, 'th[data-col|=impl] input')
-      .forEach(input => input.checked = uas.includes(input.value.split('|')[0]));
+      .forEach(input => input.checked = (uas.indexOf(input.value.split('|')[0]) !== -1));
   };
 
 

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -217,7 +217,7 @@ const browsers = {
  */
 const formatMonthAndYearDate = function (date, lang) {
   if (((lang === 'zh') || lang.startsWith('zh-')) &&
-      window._runScripts && window._virtualConsole && (window.name === 'nodejs')) {
+      window.navigator.userAgent.split(/[\s\/]/).includes('jsdom')) {
     let month = date.getMonth() + 1;
     return '' + date.getFullYear() + '年' + month + '月';
   }


### PR DESCRIPTION
Fix for #255

Also stick to `indexOf` instead of `includes` in case people are looking at the roadmap using IE (but keep `includes` in the generation logic since it should only run on modern user-agents)