### PR TITLE
[Framework] Make nav menu not dependent on JS

### DIFF
--- a/assets/css/roadmap.css
+++ b/assets/css/roadmap.css
@@ -127,8 +127,18 @@ filter: grayscale(1);*/
   background-color: transparent;
 }
 
-
 #side-nav {
+  width: 100%;
+  max-width:768px;
+  margin: auto;
+}
+
+.menu #side-nav {
+  display: none;
+}
+
+#side-nav[data-js] {
+  display: block;
   height: 100%;
   width: 80%;
   position: fixed;
@@ -149,7 +159,7 @@ filter: grayscale(1);*/
     transform: translateX(125%);
 }
 @media (min-width: 768px) {
-  #side-nav {
+  #side-nav[data-js] {
     height: 100%;
     width: 80%;
     max-width: 300px;
@@ -164,59 +174,12 @@ filter: grayscale(1);*/
   #side-nav.active {
       transform: translateX(300px);
   }
-
-}
-
-
-#side-nav header {
-  width: 100%;
-  background-color: #EF5350;
-  --border-bottom: 3px solid #D4A525;
-  padding-top: 5px;
-  border-bottom: 0.5px solid rgba(38,38,38,0.05);
-  background-size: cover;
-  background-position: center;
-  display: none;
-}
-
-#side-nav header .container {
-  flex-flow: column;
-  justify-content: space-between;
-  padding: 0px 0px 0px 10px;
-
-}
-
-#side-nav header .side-nav-controls {
-    display: flex;
-    flex-flow: row;
-    justify-content: flex-end;
-}
-
-#side-nav header .side-nav-controls button {
-  background: none;
-  border: none;
-  display: flex;
-  padding: 10px;
-}
-
-#side-nav header .side-nav-controls button img {
-  width: 15px;
-}
-
-#side-nav header h1 {
-  font-size: 1.4em;
-  color: white;
-  line-height: 1.5em;
-  font-weight: 800;
-  margin-top: 30px;
-  margin-bottom: 20px;
-  font-family: sans-serif;
 }
 
 #side-nav nav ul {
   padding: 0px;
-  margin-top: 50px;
   padding-left: 10px;
+  max-width: 300px;
 }
 
 #side-nav nav ul li {
@@ -280,45 +243,6 @@ filter: grayscale(1);*/
   display: block;
 }
 
-/* old files */
-.side-nav {
-    --padding-top: 60px;
-}
-
-.side-nav ul {
-    list-style-type: none;
-}
-
-.side-nav > ul {
-}
-
-.side-nav a {
-    text-decoration: none;
-    color: rgba(0,0,0,0.7);
-    font-size: 0.8em;
-}
-
-.side-nav a:hover {
-    text-decoration: underline;
-}
-
-.side-nav ul {
-    padding-left: 30px;
-}
-
-.side-nav ul li h2 {
-    margin-bottom: 5px;
-}
-
-.side-nav ul li h2 a {
-    font-size: 0.9em;
-    color: #547190;
-}
-
-.side-nav ul li h2 a:hover {
-    text-decoration: none;
-    color: #0072ff;
-}
 
 .hero .call-to-action {
     margin-top: 0px;

--- a/assets/css/roadmap.css
+++ b/assets/css/roadmap.css
@@ -129,7 +129,7 @@ filter: grayscale(1);*/
 
 #side-nav {
   width: 100%;
-  max-width:768px;
+  max-width: 768px;
   margin: auto;
 }
 

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -746,6 +746,10 @@ const applyToc = function (toc, translate, lang, pagetype) {
     }
   });
 
+  if (pagetype.menu) {
+    document.body.className += ' menu';
+  }
+
   let currentPage = toc.pages.find(page =>
     window.location.pathname.endsWith(page.url) ||
     window.location.pathname.endsWith(page.url.replace(/\.([^\.]+)$/, '.' + lang + '.$1')));

--- a/js/sidenav.js
+++ b/js/sidenav.js
@@ -130,8 +130,8 @@
    */
   function toggleMenu(evt) {
     if (isMenuOpened) {
-      mask.className = mask.className.replace('active', 'hidden');
-      menu.className = menu.className.replace('active', 'hidden');
+      mask.className = 'hidden';
+      menu.className = 'hidden';
       buttonImg.setAttribute('alt', actionLabels.open);
       menuItems.forEach(item => {
         item.setAttribute('tabindex', '-1');
@@ -142,8 +142,8 @@
       }
     }
     else {
-      mask.className += ' active';
-      menu.className += ' active';
+      mask.className = 'active';
+      menu.className = 'active';
       buttonImg.setAttribute('alt', actionLabels.close);
       lastActiveElement = document.activeElement;
       menuItems.forEach(item => item.setAttribute('tabindex', '0'));
@@ -155,6 +155,12 @@
     evt.stopPropagation();
     return false;
   }
+
+  // Render the "open navigation menu" button
+  button.hidden = false;
+
+  // Flag the navigation menu as JS-controlled
+  menu.setAttribute('data-js', 'true');
 
   // React to user actions that toggle the menu
   button.addEventListener('click', toggleMenu);

--- a/js/template-page.html
+++ b/js/template-page.html
@@ -14,7 +14,7 @@
 
     <header>
       <div class="container">
-        <button id="side-nav-btn" type="button" name="sidenav-opener">
+        <button id="side-nav-btn" type="button" name="sidenav-opener" hidden>
             <img src="../assets/img/menu.svg" height="15" alt="Open menu" data-altclose="Close menu" />
         </button>
         <div class="brand">
@@ -50,16 +50,17 @@
             </div>
         </section>
       </div>
+    </main>
 
-        </main>
-
-        <aside id="side-nav">
-          <nav>
-            <ul>
-            </ul>
-          </nav>
-        </aside>
+    <aside id="side-nav">
+      <h2>Roadmap pages</h2>
+      <nav>
+        <ul>
+        </ul>
+      </nav>
+    </aside>
     <div id="mask"></div>
+
         <footer>
             <div class="container">
                 <p>

--- a/js/template-page.zh.html
+++ b/js/template-page.zh.html
@@ -50,16 +50,16 @@
             </div>
         </section>
       </div>
+    </main>
 
-        </main>
-
-        <aside id="side-nav">
-          <nav>
-            <ul>
-            </ul>
-          </nav>
-        </aside>
+    <aside id="side-nav">
+      <nav>
+        <ul>
+        </ul>
+      </nav>
+    </aside>
     <div id="mask"></div>
+        
         <footer>
             <div class="container">
                 <p>


### PR DESCRIPTION
See https://github.com/w3c/web-roadmaps/issues/239

Navigation menu should still be functional when JS is not around. This update renders the menu by default towards the end of the page, allowing user to navigate even when JS is off.

When JS is off, navigation menu is not rendered on the home page because it would merely duplicate the content.

Ideally, the navigation menu would be rendered on the left of the page when screen is wide enough. Not done here because that would require a bit of code refactoring. Could be considered later on if that feels needed, but that does not seem to be a priority.