### PR TITLE
[Framework] New tool to create missing data files for W3C specs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ For the 3 first categories of features described above, a feature comes with one
 
 ## JSON format for describing specifications
 
-Each specification is described by a JSON object that will allow retrieving information about the standardization status of the spec and its level of implementation in browsers.
+Each specification is described by a JSON object that will allow retrieving information about the standardization status of the spec and its level of implementation in browsers. Note the framework will automatically generate an empty data file when it does not exist for W3C specs (see [Generate content locally](#generate-content-locally) for details), allowing authors to reference a W3C spec to start with without having to worry about creating the data file.
 
 That JSON object is stored in a file in the [data](data/) directory, whose name is then used to refer to the said specification from relevant features.
 
@@ -385,8 +385,9 @@ The `npm run all` script can take some time. If you want to have a more interact
 
 1. Create a [W3C account](https://www.w3.org/accounts/request) and a [W3C API key](https://www.w3.org/users/myprofile/apikeys) if not already done.
 2. Create a `config.json` file in the root of the repository that contains a `w3cApiKey` property with a valid W3C API key.
-3. Run `npm run generate-info` to update information and implementation data. This should generate `.out/data/tr.json` and `.out/data/impl.json` files. This step needs to be run again whenever you make changes to information in the `data` folder.
-4. Serve the root folder over HTTP (any simple HTTP server should work), and browse the roadmap files over HTTP in your favorite Web browser. Refresh the content whenever you've made changes to the HTML, JS, or data files.
+3. Run `npm run create-missing-data` to create missing data files. Only needed if you referenced new specs.
+4. Run `npm run generate-info` to update information and implementation data. This should generate `.out/data/tr.json` and `.out/data/impl.json` files. This step needs to be run again whenever you make changes to information in the `data` folder.
+5. Serve the root folder over HTTP (any simple HTTP server should work), and browse the roadmap files over HTTP in your favorite Web browser. Refresh the content whenever you've made changes to the HTML, JS, or data files.
 
 
 ## Translating a roadmap

--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -1137,7 +1137,7 @@ const fillTables = function (specInfo, implInfo, customTables, translate, lang) 
     let info = specInfo[specId];
     if (!info) {
       warnings.push('Unknown spec "' + id + '"');
-      info = { url: '', title: '' };
+      info = { url: '', title: '', status: 'ED' };
     }
     if (featureId && (!info.features || !info.features[featureId])) {
       warnings.push('Unknown feature in spec "' + id + '"');

--- a/package.json
+++ b/package.json
@@ -9,11 +9,13 @@
     "ncp": "^2.0.0"
   },
   "scripts": {
-    "all": "npm run validate-data && npm run generate-info && npm run validate-html && npm run validate-info && npm run generate-pages",
+    "all": "npm run create-missing-data && npm run validate-data && npm run generate-info && npm run validate-html && npm run validate-info && npm run generate-pages",
     "generate-info": "npm run generate-specinfo && npm run generate-implinfo",
     "generate-specinfo": "mkdirp .out/data && node tools/extract-spec-data.js data > .out/data/tr.json",
     "generate-implinfo": "mkdirp .out/data && node tools/extract-impl-data.js data > .out/data/impl.json",
     "generate-pages": "node tools/generate-roadmaps.js",
+    "create-missing-data": "node tools/create-missing-data.js",
+    "detect-missing-data": "node tools/create-missing-data.js --detect",
     "validate-data": "ajv -s tools/spec.jsons -d data/\\*.json --errors=text",
     "validate-info": "npm run validate-specinfo && npm run validate-implinfo",
     "validate-specinfo": "ajv -s tools/tr.jsons -d .out/data/tr.json --errors=text",

--- a/tools/create-missing-data.js
+++ b/tools/create-missing-data.js
@@ -1,0 +1,104 @@
+/*******************************************************************************
+Parses existing roadmap pages and creates (or reports on) missing data files.
+
+The tool also reports on data files that are not referenced anywhere.
+
+To run the tool:
+node tools/create-missing-data.js [--detect]
+
+The `--detect` option tells the tool not to create missing data files in the
+`data` folder.
+*******************************************************************************/
+
+const jsdom = require('jsdom');
+const fs = require('fs');
+const path = require('path');
+
+
+function onlyUnique(value, index, self) {
+  return self.indexOf(value) === index;
+}
+
+
+const $ = (el, selector) =>
+  Array.prototype.slice.call(el.querySelectorAll(selector), 0);
+
+
+/**
+ * Parse an HTML page and extract referenced specs
+ *
+ * @param  {String} file The roadmap page to parse
+ * @return {Promise<Array(String)>} Promise to get the list of specs referenced
+ *   in the page.
+ */
+async function extractReferencedSpecs(file) {
+  return new Promise(async (resolve, reject) => {
+    // Load the page using JSDOM
+    const virtualConsole = new jsdom.VirtualConsole();
+    let dom = await jsdom.JSDOM.fromFile(file, { virtualConsole });
+    let doc = dom.window.document;
+    let specs = $(doc, '[data-featureid]').map(el =>
+      el.getAttribute('data-featureid').split('/')[0]);
+    return resolve(specs);
+  });
+}
+
+
+/*******************************************************************************
+Main loop
+*******************************************************************************/
+// Tool creates missing data files by default. The `--detect` parameter tells
+// the tool to only report on missing data files, but not to create them.
+let detectOnly = (process.argv.length > 1) && (process.argv[2] === '--detect');
+
+// Compute the list of roadmap pages to parse
+// (same code as in `generate-roadmap.js`)
+const inputFolders = fs.readdirSync('.')
+  .filter(f => fs.statSync(f).isDirectory())
+  .filter(f => !f.startsWith('.'))
+  .filter(f => !['assets', 'data', 'js', 'node_modules', 'tools'].includes(f));
+const files = inputFolders.map(folder => {
+  return fs.readdirSync(folder)
+    .filter(f => f.endsWith('.html'))
+    .map(f => path.join(folder, f));
+}).reduce((res, files) => res.concat(files), []);
+
+// Compute the list of data files that already exist
+const knownSpecs = fs.readdirSync('data')
+  .filter(f => !fs.statSync(path.join('data', f)).isDirectory())
+  .filter(f => f.endsWith('.json'))
+  .map(f => f.replace(/.json$/, ''))
+  .filter(onlyUnique);
+
+// Parse HTML pages to extract `data-featureid` references that do not exist
+// in the "data" folder.
+console.log('Parse HTML pages to detect missing/unused data files...');
+Promise.all(files.map(file => extractReferencedSpecs(file, knownSpecs)))
+  .then(res => res.reduce((missing, specs) => missing.concat(specs), []))
+  .then(referenced => referenced.filter(onlyUnique))
+  .then(referenced => Object.assign({
+    missing: referenced.filter(spec => !knownSpecs.includes(spec)),
+    unused: knownSpecs.filter(spec => !referenced.includes(spec))
+  }))
+  .then(res => {
+    for (let spec of res.missing) {
+      if (detectOnly) {
+        console.log(`- found missing data file for "${spec}"`);
+      }
+      else {
+        fs.writeFileSync(`data/${spec}.json`, '{}\n', 'utf8');
+        console.log(`- created missing data file for "${spec}"`);
+      }
+    }
+
+    for (let spec of res.unused) {
+      console.log(`- data file "data/${spec}.json" is unused`);
+    }
+
+    console.log(`=> ${res.missing.length} missing data file(s) found`);
+    console.log(`=> ${res.unused.length} unused data file(s) found`);
+  })
+  .catch(err => {
+    console.error(err);
+    process.exit(2);
+  });

--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -240,7 +240,7 @@ async function fetchJson(url, options) {
 async function extractSpecData(files, config) {
   let specs = (files || []).map(file => Object.assign({
     file,
-    id: file.split(/\/|\\/).pop().split('.')[0],
+    id: file.split(/\/|\\/).pop().split('.').slice(0, -1).join('.'),
     data: requireFromWorkingDirectory(file)
   }));
 


### PR DESCRIPTION
See https://github.com/w3c/web-roadmaps/issues/77.

The new `create-missing-data.js` tool, integrated in `npm run all` parses the roadmap pages and creates empty data files for specs that these pages reference (in `data-featureid` attributes) when that is needed.

Note that this mechanism will only work for W3C specs, where the reference is supposed to use the spec's shortname. Generation will break at the `generate-specinfo` step otherwise, because the framework won't be able to extract any information about the spec from the W3C API.

The created data files would obviously need to be added to the repository afterwards. This remains a manual step. In any case, this seems only useful when the data file gets completed with implementation info.

Updates to the other scripts in this pull request are required to make them more resistant to situations where no spec info is available, and to accept shortnames that contain `.` (for instance `graphics-aam-1.0`)