### PR TITLE
[mobile] Mention Event Timing Web Perf API

### DIFF
--- a/data/event-timing.json
+++ b/data/event-timing.json
@@ -1,0 +1,13 @@
+{
+  "url": "https://github.com/WICG/event-timing",
+  "title": "Event Timing Web Perf API",
+  "wgs": [
+    {
+      "url": "https://www.w3.org/community/wicg/",
+      "label": "Web Platform Incubator Community Group"
+    }
+  ],
+  "impl": {
+    "chromestatus": 5167290693713920
+  }
+}

--- a/mobile/performance.html
+++ b/mobile/performance.html
@@ -82,8 +82,10 @@
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
 
-        <div data-feature="Rendering Performance">
+        <div data-feature="Timing hooks">
           <p>The work on the <a data-featureid="frame-timing">Frame Timing API</a> aims at providing detailed information on the frame-per-second obtained when an application is running on the user device.</p>
+
+          <p>The work on the <a data-featureid="event-timing">Event Timing Web Perf API</a> exposes a mechanism to measure the latency of some events triggered by user interaction.</p>
         </div>
       </section>
 


### PR DESCRIPTION
Note that I didn't add the [polyfill](https://github.com/tdresser/input-latency-web-perf-polyfill/tree/gh-pages), since it looks very rough for me...

I'll add Chinese translation in a future commit.