### PR TITLE
[mobile] Mention Identifiers for WebRTC's Statistics API

### DIFF
--- a/data/webrtc-relay.json
+++ b/data/webrtc-relay.json
@@ -1,4 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/webrtc//#dom-rtcpeerconnection-getdefaulticeservers",
+  "url": "https://www.w3.org/TR/webrtc/#dom-rtcpeerconnection-getdefaulticeservers",
   "feature": "Browser default ICE servers"
 }

--- a/data/webrtc-stats.json
+++ b/data/webrtc-stats.json
@@ -1,0 +1,6 @@
+{
+    "url": "https://www.w3.org/TR/webrtc-stats/",
+    "impl": {
+      "chromestatus": 5665052275245056
+    }
+}

--- a/mobile/performance.html
+++ b/mobile/performance.html
@@ -77,6 +77,10 @@
         <div data-feature="Infinite scrolling">
           <p>The use of <b>infinite scrolling</b> lists, where more and more content is loaded and rendered as the user scrolls, is very common on mobile devices. Such lists provide a better user experience than pagination on touch screens. Applications unfortunately need to continuously poll layout information of DOM elements <em>synchronously</em> to implement this pattern, which is a source of significant performance overhead. The <a data-featureid="intersectionobserver">Intersection Observer</a> specification defines an API to <em>asynchronously</em> observe changes in the intersection of a target element with an ancestor element or with a top-level document's viewport, providing an efficient mechanism to retrieve the information needed to implement infinite scrolling.</p>
         </div>
+
+        <div data-feature="Real-time Communication">
+          <p>The <a data-featureid="webrtc-stats">Identifiers for WebRTC's Statistics API</a> defines a set of WebIDL objects that allow access to the statistical information about a RTCPeerConnection, allowing web apps to monitor the performance of the underlying network and media pipeline.</p>
+        </div>
       </section>
 
       <section class="featureset exploratory-work">


### PR DESCRIPTION
Fix #279.

The `chromestatus` is for `getStats`, which is defined in the webrtc-pc spec. However, the webrtc-stats spec defines the objects returned by `getStats`, so I think it's probably fine to use the `chromestatus` id.

This PR also fixes a URL in `data/webrtc-relay.json`.

(Chinese translation will be made in a future commit.)