### PR TITLE
[Mobile] Fix reference to CSS contain property

### DIFF
--- a/mobile/performance.html
+++ b/mobile/performance.html
@@ -78,7 +78,7 @@
 
         <div data-feature="Rendering performance">
           <p>To ensure optimal performance when animating parts of an app, developers can make use of the <a data-featureid="css-will-change">CSS <code>will-change</code></a> property to let browsers compute the animation ahead of its occurrence.</p>
-          <p>The CSS <a data-feature-id="css-contain">contain</a> property can indicate that the element’s subtree is independent of the rest of the page. This also enables heavy optimizations by user agents when used well, in particular to skip over content that is off-screen knowing that it won't affect the rendering of the content that is on-screen.</p>
+          <p>The CSS <a data-featureid="css-contain">contain</a> property can indicate that the element’s subtree is independent of the rest of the page. This also enables heavy optimizations by user agents when used well, in particular to skip over content that is off-screen knowing that it won't affect the rendering of the content that is on-screen.</p>
         </div>
 
         <div data-feature="Low-level Bytecode Format">


### PR DESCRIPTION
Fix #297. `data-feature-id` was used instead of `data-featureid`.