### PR TITLE
[Mobile] Mention overscroll-behavior

### DIFF
--- a/data/css-overscroll-behavior.json
+++ b/data/css-overscroll-behavior.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://wicg.github.io/overscroll-behavior/",
+  "impl": {
+    "caniuse": "css-overscroll-behavior",
+    "chromestatus": 5734614437986304,
+    "mdn": "css.properties.overscroll-behavior"
+  }
+}

--- a/mobile/performance.html
+++ b/mobile/performance.html
@@ -110,6 +110,10 @@
         <div data-feature="Animation Optimization">
           <p>The <a data-featureid="animation-worklet">CSS Animation Worklet API</a> provides a method to create scripted animations that control a set of animation effects. The API is designed to make it possible for user agents to run such animations in their own dedicated thread to provide a degree of performance isolation from main thread.</p>
         </div>
+
+        <div data-feature="Scrolling Optimization">
+          <p>User agents may implement default rules for scrolling such as scroll chaining and overscroll affordances that web applications may wish to disable to enhance <b>pull-to-refresh</b> and <b>infinite scrolling</b> interaction paradigms, which are common on mobile devices. This can be achieved through scripting, but negatively affects scrolling performances as the application needs to listen to touch events without setting the <code>passive</code> flag to override the default behavior when needed. The <a data-featureid="css-overscroll-behavior">CSS <code>overscroll-behavior</code></a> property introduces control over the behavior of a scroll container when its scrollport reaches the boundary of its scroll box, allowing web applications to disable default rules for scrolling efficiently.</p>
+        </div>
       </section>
 
       <section>


### PR DESCRIPTION
The `overscroll-behavior` property is useful e.g. to implement pull-to-refresh and infinite scrolling efficiently. Mentioned in Performance and tuning.

Note the draft is still undergoing transition from the WICG to the CSS WG. The URL of the spec may need to be updated when that transition is complete (and the mention may need to be moved out of the "Exploratory work" section).

Fix #258.