### PR TITLE
[Media] Update TTWG deliverables in rendering page

### DIFF
--- a/data/ttml-imsc1.json
+++ b/data/ttml-imsc1.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.w3.org/TR/ttml-imsc1/",
+  "url": "https://www.w3.org/TR/ttml-imsc1.0.1/",
   "polyfills": [
     {
       "label": "imscJS",

--- a/media/rendering.html
+++ b/media/rendering.html
@@ -18,12 +18,15 @@
           <p>Beyond the declarative approach enabled by the <code>&lt;audio&gt;</code> element, the <a data-featureid="webaudio">Web Audio API</a> provides a full-fledged audio processing API, which includes support for low-latency playback of audio content.</p>
         </div>
 
-        <p data-feature="Rendering of captions"><a data-featureid="webvtt">WebVTT</a> is a file format for captions and subtitles. The specification is still a Working Draft, but the format is already supported at various levels among browsers, allowing to render text tracks through a <code>&lt;video&gt;</code> element. The <a data-featureid="ttml1">Timed Text Markup Language</a> (TTML) specification provides a richer language for describing timed text. It is used both as an interchange format among authoring systems and for delivery of subtitles and captions worldwide, in particular through profiles such as the <a data-featureid="ttml-imsc1">IMSC1 profile</a>. Some browsers may not support IMSC1 natively, but note Web applications can still take advantage of IMSC1 through libraries such as the <a href="https://github.com/sandflow/imscJS">imscJS polyfill library</a>, which is a complete implementation of the IMSC1 profile in JavaScript and renders IMSC1 documents to HTML5.</p>
+        <p data-feature="Rendering of captions"><a data-featureid="webvtt">WebVTT</a> is a file format for captions and subtitles. The specification is still a Working Draft, but the format is already supported at various levels among browsers, allowing to render text tracks through a <code>&lt;video&gt;</code> element. The <a data-featureid="ttml1">Timed Text Markup Language</a> (TTML) specification provides a richer language for describing timed text. It is used both as an interchange format among authoring systems and for delivery of subtitles and captions worldwide, in particular through profiles such as the <a data-featureid="ttml-imsc1">IMSC1 (Internet Media Subtitles and Captions) profile</a>. Some browsers may not support IMSC1 natively, but note Web applications can still take advantage of IMSC1 through libraries such as the <a href="https://github.com/sandflow/imscJS">imscJS polyfill library</a>, which is a complete implementation of the IMSC1 profile in JavaScript and renders IMSC1 documents to HTML5.</p>
         <p data-feature="Rendering of protected media">For the distribution of media whose content needs specific protection from copy, <a data-featureid="eme">Encrypted Media Extensions</a> (EME) enables Web applications to render encrypted media streams based on Content Decryption Modules (CDM).</p>
         <p data-feature="Rendering of media fragments">Users often want to share a pointer to a specific position within the timeline of a video (or an audio) feed with friends on social networks, and expect media players to jump to the requested position right away. The <a data-featureid="media-frags">Media Fragments URI</a> specification defines a syntax for constructing media fragment URIs and explains how Web browsers can use this information to render the media fragment.</p>
       </section>
       <section class="featureset in-progress">
         <h2>Specifications in progress</h2>
+        <div data-feature="Rendering of captions">
+          <p>The <a data-featureid="ttml">Timed Text Markup Language 2</a> (TTML2) specification extends TTML1 with advanced features for animations, styling, embedded content and metadata. The <a data-featureid="ttml-imsc11">IMSC1.1 profile</a>, backwards compatible with the IMSC1 profile, is based on TTML2.</p>
+        </div>
         <div data-feature="Distributed rendering">
           <p>As users increasingly own more and more connected devices, the need to get these devices to work together increases as well:</p>
           <ul>
@@ -39,7 +42,6 @@
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
         <div data-feature="Rendering of captions">
-          <p>The <a data-featureid="ttml">Timed Text Markup Language 2</a> (TTML2) specification extends TTML1 with advanced features for animations, styling, embedded content and metadata.</p>
           <p>Providing an alternative transcript to media content is a well-known best practice; a <a data-featureid="transcript">transcript extension</a> to HTML has been proposed to make an explicit link between media content and their transcript and thus facilitate discovery and consumption.</p>
         </div>
         <div data-feature="Distributed rendering">


### PR DESCRIPTION
To address issues raised in #283:
- the URL of the IMSC1 spec was updated to target the 1.0.1 Rec.
- TTML2 was moved from "Exploratory work" to "Specification in progress"
- IMSC1.1 gets mentioned in relation with TTML2.

The page lists the 3rd edition of TTML1 already, which seems fine.