### PR TITLE
[Framework] Fix URL generation for Specref reverse lookup

### DIFF
--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -236,11 +236,7 @@ function getIdForReverseLookup(spec) {
     }
   }
   else {
-    let parts = specUrl.split('#')[0].split('/');
-    if (parts[parts.length - 1].endsWith('.html')) {
-      parts = parts.slice(0, -1);
-    }
-    return parts.join('/');
+    return specUrl.split('#')[0];
   }
 }
 


### PR DESCRIPTION
The lookup URL that was created dropped the final HTML filename for some reason for non-TR specs, but Specref needs it to identify the spec that the request is about.

For instance, Specref returns useful info for:
`https://wicg.github.io/page-lifecycle/spec.html`

... but won't return anything for:
`https://wicg.github.io/page-lifecycle/`

The final HTML filename is now kept.