### PR TITLE
[Games] Add first draft of Games on the Web roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ It aims at simplifying the creation and maintenance of such roadmaps by collecti
 * [Roadmap of Web Applications on Mobile](https://w3c.github.io/web-roadmaps/mobile/)
 * [Roadmap of Technologies Needed for Web Publications](https://w3c.github.io/web-roadmaps/publishing/)
 * [Spatial data on the Web Roadmap](https://w3c.github.io/web-roadmaps/sdw/)
+* [Games on the Web Roadmap](https://w3c.github.io/web-roadmaps/games/)
 
 ## Table of contents
 * [Overview of the framework](#overview-of-the-framework)

--- a/data/offscreencanvas.json
+++ b/data/offscreencanvas.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://html.spec.whatwg.org/multipage/canvas.html#the-offscreencanvas-interface",
+  "title": "HTML (Living Standard)",
+  "feature": "OffscreenCanvas",
+  "impl": {
+    "caniuse": "offscreencanvas",
+    "chromestatus": 5681560598609920,
+    "mdn": "api.OffscreenCanvas"
+  }
+}

--- a/data/web-locks.json
+++ b/data/web-locks.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://wicg.github.io/web-locks/",
+  "title": "Web Locks API",
+  "impl": {
+    "chromestatus": 5712361335816192,
+    "mdn": "api.Navigator.locks"
+  }
+}

--- a/data/webgl.json
+++ b/data/webgl.json
@@ -1,0 +1,11 @@
+{
+  "url": "https://www.khronos.org/registry/webgl/specs/latest/1.0/",
+  "status": "REC",
+  "impl": {
+    "caniuse": "webgl",
+    "chromestatus": 6049512976023552,
+    "edgestatus": "WebGL  (Canvas 3D)",
+    "mdn": "api.HTMLCanvasElement.webgl_context",
+    "webkitstatus": "specification-webgl-1"
+  }
+}

--- a/games/about.html
+++ b/games/about.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>About this document</title>
+  </head>
+  <body>
+    <header>
+      <h1>About this document</h1>
+    </header>
+    <main data-contents="about"></main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/index.html
+++ b/games/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Games on the Web Roadmap</title>
+  </head>
+  <body>
+    <header>
+      <h1>Games on the Web Roadmap</h1>
+      <p>This document summarizes the technologies developed in W3C and elsewhere that enable the creation of performant and immersive games on the Web.</p>
+    </header>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/lifecycle.html
+++ b/games/lifecycle.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Progressive Web Applications</title>
+  </head>
+  <body>
+    <header>
+      <h1>Progressive Web Applications</h1>
+
+      <p>An important aspect of Web gaming experiences is linked to how the game integrates with the rest of the system to provide a native-like experience that features a responsive user interface that is permanently available, even when offline, installable on the user's home screen, and re-engageable (meaning that it is easy to push notifications to the user to re-engage her into the game).</p>
+
+      <p>These notions are part of the overall <strong>application lifecycle</strong>: how applications get installed, shown to the user in applications list, started, stopped, woken up from remote notifications, synced up when the device goes on-line. They form the backbone of <strong>Progressive Web Applications</strong> (PWA).</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+
+        <div data-feature="Foreground detection">
+          <p>The <a data-featureid="page-visibility">Page Visibility</a> specification lets developers detect when their application is in the foreground, and thus adapt their operations and resource consumption accordingly.</p>
+        </div>
+
+        <p data-feature="Notification">Mobile devices follow their users everywhere, and many mobile users rely on them to remind them or notify them of events, such as messages: the <a data-featureid="notifications">Web Notifications</a> specification enables that feature in the Web environment.</p>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+
+        <div data-feature="Screen wake lock">
+          <p>Games may want to engage their users for a relatively long period of time. The <a data-featureid="wake-lock">Wake Lock API</a> lets developers signal the needs to keep the screen up in these circumstances, avoiding situations where the screen gets turned off by mistake to save battery.</p>
+        </div>
+
+        <div data-feature="Packing">
+          <p>Whether packaged or not, users rely on a variety of metadata (name, icons) to identify the apps they want to use among their list of regularly used applications. The <a data-featureid="appmanifest">Web App Manifest</a> specification lets developers group all these metadata into a single JSON file.</p>
+        </div>
+
+        <div data-feature="Offline Web apps">
+          <p>The <a data-featureid="serviceworkers">Service Workers</a> specification describes a method that enables applications to take advantage of persistent background processing, opening the door to running applications offline.</p>
+          <p>Not only does Service Workers enables Web applications to work seamlessly offline or in poor network conditions, it also creates a model for Web applications to operate when they have not been opened in a browser window, or even if the browser itself is not running. That ability opens the door for Web applications that run in the background and can react to remotely triggered events.</p>
+        </div>
+
+        <div data-feature="Notifications">
+          <p>The <a data-featureid="push">Push API</a> enables Web applications to subscribe to remote notifications that, upon reception, wake them up. Native applications have long enjoyed the benefits of greater user engagement that these notifications bring.</p>
+        </div>
+
+        <div data-feature="Background execution">
+          <p>The <a data-featureid="background-sync">Web Background Synchronization</a> specification builds on top of Service Workers to enable Web applications to keep their user data up to date seamlessly, by running network operations in the background, adjusting to possibly unreliable connections that users often experience on mobile devices.</p>
+        </div>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+
+        <div data-feature="Packing">
+          <p>The <a data-featureid="packaging">Web Packaging</a> document describes use cases for a new package format for web sites and applications and outlines such a format.</p>
+        </div>
+
+        <div data-feature="State transition">
+          <p>Applications, notably those running on mobile devices, can go through different application states, from running to being idle, paused, stopped, discarded, or terminated. Transitions between these states are triggered by the underlying operating system, and hidden from web applications. The <a data-featureid="page-lifecycle">Page Lifecycle</a> proposal seeks to expose application state transitions to applications so that these applications can persist/restore state, enable/disable use of network, etc.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Discontinued features</h2>
+
+        <dl>
+          <dt>Application caches</dt>
+          <dd>The <a data-featureid="appcache">application cache</a> mechanism was introduced in HTML5 to enable access to Web applications offline through the definition of a manifest of files that the browser is expected to keep in its cache. The feature is well deployed but raises security issues and is extremely limited in terms of how much developers can control what gets cached when. The feature was obsoleted in HTML 5.1, and dropped from HTML 5.2, in favor of the <a href="https://www.w3.org/TR/service-workers-1/">Service Workers</a> specification, which defines a much more powerful approach.</dd>
+
+          <dt>Task Scheduling</dt>
+          <dd>The <a data-featureid="task-scheduler">Task Scheduler API</a> made it possible to trigger a task at a specified time via the service worker associated with a Web app. This specification was in scope of the now-closed System Applications Working Group and was shelved as a result.</dd>
+
+          <dt>Geofencing API</dt>
+          <dd>The <a data-featureid="geofencing">Geofencing API</a> made it possible to wake up a Web app when a device enters a specified geographical area. This work has been discontinued, partly out of struggles to find a good approach to permission needs that such an API triggers to protect users against privacy issues. Work on this specification could resume in the future depending on interest from would-be implementers.</dd>
+
+          <dt>Background execution budget</dt>
+          <dd>User agents will restrict the ability for Web applications to run operations in the background so that users remain in control of what an application can do at all times. The <a data-featureid="budget-api">Web Budget API</a> proposed a mechanism by which applications could determine the cost and budget at their disposal to run operations in the background, allowing them to decide whether to perform or postpone these operations. The proposal was shelved for lack of support.</dd>
+        </dl>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/network.html
+++ b/games/network.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Network and Communications</title>
+  </head>
+  <body>
+    <header>
+      <h1>Network and Communications</h1>
+      <p>Games need to access the network for a variety of reasons, including for downloading next level's assets, for bidirectional data transfers with the game's server, and for multiplayer communications in real-time. The Web platform is growing a number of APIs that facilitate establishing network connectivity in different contexts.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+            
+        <div data-feature="HTTP network API">
+          <p>The <a data-featureid="fetch">Fetch API</a> provides a powerful Promise-based API to load content from Web servers using the HTTP and HTTPS protocols. It replaces the former <a data-featureid="xhr">XMLHttpRequest</a> API, which was at the heart of Ajax development (XMLHttpRequest may still be used).</p>
+        </div>
+            
+        <div data-feature="Cross-domain requests">
+          <p>By default, browsers do not allow to make request across different domains (or more specifically, across different origins, a combination of the protocol, domain and port) from a single Web page; this rule protects users from having a Web site abusing their credentials and stealing their data on another Web site. Sites can opt-out of that rule by making use of the <a data-featureid="cors">Cross-Origin Resource Sharing</a> (CORS) mechanism, opening up much wider cooperation across Web applications and services. Note the W3C version of the CORS specification does not reflect current implementations and will be obsoleted. The CORS mechanism is now a core part of the on-going <a href="https://fetch.spec.whatwg.org/">Fetch specification</a> in the WHATWG.</p>
+        </div>
+            
+        <div data-feature="Server-pushed requests">
+          <p>XMLHttpRequest is useful for client-initiated network requests, but mobile devices with their limited network capabilities and the cost that network requests induce on their battery (and sometimes on their users bill) can often make better use of server-initiated requests. The <a data-featureid="eventsource">Server-Sent Events API</a> allows triggering DOM events based on push notifications (via HTTP and other protocols).</p>
+        </div>
+            
+        <div data-feature="Bidirectional connections">
+          <p>The <a data-featureid="websockets">WebSocket API</a>, built on top of the <a href="https://tools.ietf.org/html/rfc6455">IETF WebSocket protocol</a> (RFC6455), offers a bidirectional, more flexible, and less resource intensive network connectivity than fetch and XMLHttpRequest.</p>
+        </div>
+
+        <div data-feature="Offline detection">
+          <p>Of course, an important part of using network connectivity relies on being able to determine if such connectivity exists, and the type of network available. The <a data-featureid="online">HTML5 <code>onLine</code> DOM flag</a>, and its associated change event, <code>online</code>, signals when network connectivity is <i>not</i> available to the Web environment (note the flag is unreliable to assert that the Web environment is online).</p>
+        </div>
+
+        <div data-feature="Network characteristics">
+          <p>The <a data-featureid="resource-timing">Resource Timing API</a> allows to measure the impact of the network on the time needed to load various resources, offering another approach to adapt a Web app to its networking environment.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+        <div data-feature="Peer-to-peer communications">
+          <p>The work on <a data-featureid="p2p">Web Real-Time Communications</a> provides direct <strong>peer-to-peer connections</strong> between browsers with real-time characteristics, ideal to manage in-game communication in multiplayer games. Streams exchanged may include data, audio, and video tracks. WebRTC may also be used to communicate with the game's server, effectively replacing the WebSocket API.</p>
+        </div>
+
+        <div data-feature="Low-level I/O">
+          <p>The <a data-featureid="streams">Streams</a> specification provides APIs for creating, composing, and consuming streams of data efficiently. Network conditions may fluctuate in mobile networks and bandwidth may be restricted; access to low-level I/O primitives enable flow control within Web applications to adjust the network delivery to some reader's speed (e.g. a media player), and perceived rendering performance improvements, e.g. when a Service Worker assembles a stream from content previously cached and content fetched online to speed up the first set of render operations of a page. The ability to cancel a stream to stop download at any time also helps reclaim network bandwidth for other tasks as soon as needed.</p>
+        </div>
+
+        <p data-feature="HTTP network API">The <a data-featureid="beacon">Beacon API</a> aims at letting developers queue unsupervised HTTP requests, leaving it to the browser to execute them when appropriate, opening the door for better network optimizations.</p>
+
+        <div data-feature="Server-pushed requests">
+          <p>The <a data-featureid="push">Push API</a> allows Web applications to receive server-sent messages whether or not the said Web app is active in a browser window. The <a href="https://datatracker.ietf.org/wg/webpush/documents/">IETF Web-Based Push Notifications Working Group</a> developed a companion protocol suitable to request the delivery of a push message to a user agent, create new push message delivery subscriptions, and monitor for new push messages (<a href="https://tools.ietf.org/html/rfc8030">RFC 8030</a>).</p>
+        </div>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+        <p>Early work on a <a data-featureid="background-sync">Web Background Synchronization API</a> would provide a robust Service Worker-based mechanism to enable Web applications to download and upload content in the background, even in the absence of a running browser.</p>
+
+        <div data-feature="Network characteristics">
+          <p>Discontinued work on the <a data-featureid="netinfo">Network Information API</a> to address discovery of the network characteristics has now been resumed in the Web Platform Incubator Community Group.</p>
+        </div>
+      </section>   
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/payment.html
+++ b/games/payment.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Payment and Services</title>
+  </head>
+  <body>
+    <header>
+      <h1>Payment and Services</h1>
+      <p>Native mobile application stores have made it much easier for developers to monetize some of their applications, either by selling the application itself to users, or by providing in-app purchases. This capacity comes at a cost as part of the money goes directly to application stores.</p>
+      <p>Payments on the Web have always been doable but process was tedious. New technologies are now streamlining payments on the Web. The icing on the cake is that application stores are not mandatory on the Web and payment services do not need to go through such intermediaries.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+
+        <p data-feature="Autocomplete">HTML provides specific help for <a data-featureid="autocomplete">autocomplete of credit card details</a> (through the <code>cc-<em>xxx</em></code> autocomplete tokens), making it easier to pay via credit cards once these details have been entered once.</p>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+
+        <p>Following a successful <a href="https://www.w3.org/2013/10/payments/">workshop on Web payments</a> in 2014 and discussions on <a href="https://www.w3.org/TR/web-payments-use-cases/">use cases and priorities for Web payments</a> in the <a href="https://www.w3.org/Payments/IG/">Web Payment Interest Group</a>, W3C <a href="https://www.w3.org/Payments/WG/charter-201510.html">chartered a Web Payments Working Group</a> to develop browser APIs to facilitate payment operations in Web applications:</p>
+
+        <ul data-feature="Web Payment">
+          <li>The <a data-featureid="payment-request">Payment Request API</a> defines an API to allow merchants (i.e. web sites selling physical or digital goods) to utilize one or more payment methods with minimal integration. In this model, browsers facilitate the payment flow between merchant and user.</li>
+          <li>The <a data-featureid="payment-method-id">Payment Method Identifiers</a> specification defines payment method identifiers and how they are validated, and, where
+          applicable, minted and formally registered with the W3C.</li>
+          <li>The <a data-featureid="payment-method-manifest">Payment Method Manifest</a> specification defines a machine-readable manifest file that describes default payment applications that are associated with a given payment method, as well as the list of origins that are permitted to provide payment applications for this payment method.</li>
+          <li>The <a data-featureid="payment-method-basic-card">Payment Method: Basic Card</a> specification describes data structures that enable the use of debit, credit, or prepaid cards in the Payment Request API.</li>
+          <li>The <a data-featureid="payment-handler">Payment Handler API</a> defines a standard way to initiate payment requests from Web pages and applications.</li>
+        </ul>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/performance.html
+++ b/games/performance.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Performance and Tuning</title>
+  </head>
+  <body>
+    <header>
+      <h1>Performance and Tuning</h1>
+      <p>Many games push platforms to their limits in terms of memory, rendering, and computation power to wow their audience. Initially, the Web platform was at a clear disadvantage here compared to native platforms, as it featured an interpreted scripting language (JavaScript) that ran in a monothread CPU-based environment and did not offer any access to the GPU. However, things have drastically improved on the Web in terms of performance in the past few years, allowing Web applications to take full advantage of available power and to measure performance to adjust parameters in real-time.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+
+        <div data-feature="Multithreading">
+          <p>To guarantee a smooth experience no matter what and take advantage of available processing power, games typically split the work across multiple threads. <a data-featureid="webworkers">Web Workers</a> allow to run JavaScript code in the background. This is particularly useful to keep the user interface responsive by offloading the most resource-intensive operations into a background process.
+          </p>
+          <p><strong>Note:</strong> Due to <a href="https://meltdownattack.com/">Spectre</a>, support for the <code>SharedArrayBuffer</code> object, which allows to share memory between threads, has been temporarily removed from most Web browsers. As such communications between workers is mostly limited to message passing for the time being.</p>
+        </div>
+
+        <div data-feature="Timing hooks">
+          <p>The <a href="https://www.w3.org/webperf/">Web Performance Working Group</a> developed a number of specifications that expose timing hooks to Web applications, to analyze time spent doing various tasks. The <a data-featureid="hr-time">High-Resolution Time</a> exposes a monotonic sub-millisecond resolution clock to Web applications so that they can precisely measure time elapsed between two events. The <a data-featureid="performance-timeline">Performance Timeline</a> defines a unified interface to store and retrieve performance metric data. Individual performance metric interfaces are defined in separate specifications:</p>
+
+          <ul>
+            <li><a data-featureid="navigation-timing">Navigation Timing</a> exposes timing information related to navigation and elements;</li>
+            <li><a data-featureid="resource-timing">Resource Timing</a> exposes timing information for resources in a document;</li>
+            <li><a data-featureid="user-timing">User Timing</a> help applications measure the performance of their applications using high precision timestamps.</li>
+          </ul>
+        </div>
+
+        <div data-feature="Priority handling">
+          <p>The <a data-featureid="requestidlecallback">Cooperative Scheduling of Background Tasks specification</a> defines the <code>requestIdleCallback</code> method that allows scheduling an operation at the next opportunity when the app is not processing another operation.</p>
+        </div>
+
+        <div data-feature="Animation optimization">
+          <p>The <a data-featureid="animation-frames">Timing control for script-based animations API</a> can help reduce the usage of resources needed for playing animations.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+
+        <div data-feature="Low-level bytecode format">
+          <p>Games that require tight memory and processing controls are typically written in C++ (or equivalent). <a data-featureid="webassembly">WebAssembly</a> (Wasm) is a low-level bytecode format that runs with near-native speed in web browsers and supports compilation from C, C++, and other languages.  Most 3D game engines now support WebAssembly as a compilation target. Wasm makes it possible to reuse the same efficient codebase across platforms.</p>
+        </div>
+
+        <div data-feature="Network prioritization">
+          <p>The <a data-featureid="resource-hints">Resource Hints</a> and <a data-featureid="preload">Preload</a> specifications let developers optimize the download of resources by enabling to delay either the download or the execution of the downloaded resource.</p>
+        </div>
+
+        <div data-feature="Caching">
+          <p>The <a data-featureid="serviceworkers">Service Workers</a> specification defines a mechanism that allows applications to intercept outgoing network requests and respond to them directly. Applications can take advantage of this mechanism to implement a flexible cache logic directly and thus avoid lengthy requests to the server.</p>
+        </div>
+
+        <div data-feature="Timing hooks">
+          <p><a data-featureid="server-timing">Server Timing</a> enables a server to communicate performance metrics about the request-response cycle to the user agent, and allows applications to act on these metrics to optimize application delivery.</p>
+          <p>The <a data-featureid="longtasks">Long Tasks API</a> exposes a mechanism to detect long running tasks that monopolize the user interface's main thread for extended periods of time.</p>
+          <p>The <a data-featureid="paint-timing">Paint Timing</a> specification allows the application to capture a series of key moments such as first paint and first contentful paint during page load.</p>
+        </div>
+
+        <div data-feature="Rendering performance">
+          <p>To ensure optimal performance when animating parts of an app, developers can make use of the <a data-featureid="css-will-change">CSS <code>will-change</code></a> property to let browsers compute the animation ahead of its occurrence.</p>
+          <p>The CSS <a data-featureid="css-contain">contain</a> property can indicate that the element’s subtree is independent of the rest of the page. This also enables heavy optimizations by user agents when used well, in particular to skip over content that is off-screen knowing that it won't affect the rendering of the content that is on-screen.</p>
+        </div>
+
+        <div data-feature="Real-time communications">
+          <p>The <a data-featureid="webrtc-stats">Identifiers for WebRTC's Statistics API</a> defines a set of Web IDL objects that allow access to the statistical information about a RTCPeerConnection, allowing web apps to monitor the performance of the underlying network and media pipeline.</p>
+        </div>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+
+        <div data-feature="GPU computation">
+          <p>On top of for rendering, some games may also wish to take advantage of the GPU to run heavy computations. To some extent, this is already doable through <a data-featureid="webgl">WebGL</a>. The <a href="https://www.w3.org/community/gpu">GPU for the Web Community Group</a> is designing a new Web API to expose modern 3D graphics (first) and computation capabilities (afterwards) in a performant, powerful and safe manner, with a view to being agnostic of and compatible with existing native system platforms such as Direct3D, Metal, or Vulkan.</p>
+        </div>
+
+        <div data-feature="Multithreading">
+          <p>Coordination between threads may require the use of locks. The <a data-featureid="web-locks">Web Locks API</a> proposal describes a mechanism that allows scripts to asynchronously acquire a lock over a resource, hold it while work is performed, then release it.</p>
+        </div>
+
+        <div data-feature="Timing hooks">
+          <p>The work on the <a data-featureid="frame-timing">Frame Timing API</a> aims at providing detailed information on the frame-per-second obtained when an application is running on the user device.</p>
+
+          <p>The work on the <a data-featureid="event-timing">Event Timing Web Perf API</a> exposes a mechanism to measure the latency of some events triggered by user interaction.</p>
+        </div>
+
+        <div data-feature="Network prioritization">
+          <p>The <a data-featureid="priority-hints">Priority Hints</a> specification lets developers signal the priority of each resource they need to download, complementing existing browser loading primitives such as preload.</p>
+        </div>
+
+        <div data-feature="Animation optimization">
+          <p>The <a data-featureid="animation-worklet">CSS Animation Worklet API</a> provides a method to create scripted animations that control a set of animation effects. The API is designed to make it possible for user agents to run such animations in their own dedicated thread to provide a degree of performance isolation from main thread.</p>
+        </div>
+
+        <div data-feature="Scrolling optimization">
+          <p>User agents may implement default rules for scrolling such as scroll chaining and overscroll affordances that web applications may wish to disable to enhance <b>pull-to-refresh</b> and <b>infinite scrolling</b> interaction paradigms, which are common on mobile devices. This can be achieved through scripting, but negatively affects scrolling performances as the application needs to listen to touch events without setting the <code>passive</code> flag to override the default behavior when needed. The <a data-featureid="css-overscroll-behavior">CSS <code>overscroll-behavior</code></a> property introduces control over the behavior of a scroll container when its scrollport reaches the boundary of its scroll box, allowing web applications to disable default rules for scrolling efficiently.</p>
+        </div>
+      </section>
+
+      <section>
+        <h2>Features not covered by ongoing work</h2>
+        <dl>
+          <dt>Artificial Intelligence (AI)</dt>
+          <dd>Many games implement a so-called game AI to generate intelligent behaviors for game characters that are not under the control of a real player. While the concept of AI in games is different from the notion of AI in other fields, a game AI may reuse similar techniques, e.g. based on machine learning, neural networks and other data mining algorithms. A sub-ideal solution to implement such algorithms in Web browsers is to use <a data-featureid="webassembly">WebAssembly</a> and <a data-featureid="webgl">WebGL</a>. An early proposal for a <a href="https://angelokai.github.io/WebML/">Base Machine Learning API</a> was made in October 2017 to expose more suitable primitives to Web applications, but has not yet led to standardization work in that field at W3C.</dd>
+        </dl>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/rendering.html
+++ b/games/rendering.html
@@ -1,0 +1,69 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Rendering</title>
+  </head>
+  <body>
+    <header>
+      <h1>Rendering</h1>
+      <p>Games are graphical in essence and need precise control over the content rendered, be it on screen or on output audio devices. The Web platform provides the ability to draw/manipulate 2D/3D graphics, as well as to render spatialized audio content. Games may of course also leverage <a href="https://www.w3.org/html/">HTML</a> and <a href="https://www.w3.org/Style/CSS/">CSS</a> (Cascading Style Sheets) to control the layout of their user interface.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+
+        <div data-feature="2D/3D graphics">
+          <p>The HTML <strong><code>&lt;canvas&gt;</code></strong> element can be used to draw graphics via scripting. The element may be used to render 2D graphics through the <a data-featureid="canvas">2D programmatic API</a>, and 3D graphics through <a data-featureid="webgl">WebGL</a>, a technology developed outside of W3C by the <a href="https://www.khronos.org/">Khronos Group</a>.</p>
+
+          <p>Vector graphics can also be rendered using <a data-featureid="svg11">SVG</a> (Scalable Vector Graphics), an XML-based markup language to describe two-dimensions vector graphics. Since these graphics are described as a set of geometric shapes, they are well-suited to create interfaces that can be zoomed in/out. SVG objects can also easily be animated, enabling the creation of very advanced and slick user interfaces.</p>
+        </div>
+
+        <div data-feature="Viewport control">
+          <p>Another important aspect for games is the possibility to use the entire screen to display the user interface; the <a data-featureid="fullscreen">Fullscreen API</a> allows to request and detect full screen display.</p>
+        </div>
+        
+        <div data-feature="Audio rendering">
+          <p>The <a data-featureid="webaudio">Web Audio API</a> provides a low latency audio processing and synthesizing API that games can use to render audio precisely. The API supports a number of features, including spatialized audio mechanisms and a convolution engine for a wide range of linear effects. A declarative approach, based on the HTML <code>&lt;audio&gt;</code> element may be used for scenarios that do not require tight controls over audio rendering, e.g. for background music.</p>
+        </div>
+
+        <div data-feature="Animations">
+          <p>Animations can be described declaratively via <a data-featureid="css-animations">CSS Animations</a> and <a data-featureid="css-transitions">CSS Transitions</a>.</p>
+          <p>Scripted animations can be resource intensive, especially on constrained devices. The possibility offered by the <a data-featureid="animation-frames">Animation Frames</a> to manage the rate of updates to animations can help to keep them under control.</p>
+        </div>
+
+        <div data-feature="Graphical effects">
+          <p>Features in CSS 3 and beyond define simple yet powerful features to create graphical effects, such as <a data-featureid="css-border-radius">rounded corners</a>, <a data-featureid="css-box-shadow">shadow effects</a>, and <a data-featureid="css-2d">rotated content</a>.</p>
+          <p>Various layout modes may also be used to create user interfaces that adapt to the user's device, including <a data-featureid="css-flexbox">CSS Flexbox</a> and <a data-featureid="css-grid-1">CSS Grid</a>, that make it possible to preserve a clear separation between the content itself (HTML, SVG) and its layout by allowing re-ordering of elements on screen, without having to change the underlying HTML.</p>
+        </div>
+
+        <div data-feature="Downloadable fonts">
+          <p>Fonts play also an important role in building appealing graphical interfaces. <a data-featureid="woff2">WOFF</a> (Web Open Font Format) makes it easy to use fonts that are automatically downloaded through style sheets, while keeping the size of the downloaded fonts limited to what the game actually needs.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+        <div data-feature="Animations">
+          <p>Animations can also be managed via scripting through the API exposed in <a data-featureid="web-animations">Web Animations</a>.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Exploratory work</h2>
+        <div data-feature="VR/AR rendering">
+          <p>The <a data-featureid="webxr">WebXR Device API</a> specification is a low-level API that allows applications to access and control head-mounted displays (HMD) using JavaScript to create compelling Virtual Reality (VR) / Augmented Reality (AR) experiences. While the API should still be considered unstable at this stage, note main browsers implement at least a subset of it, or of the previous <a data-featureid="webvr">WebVR specification</a>, making it possible to develop Web-based VR/AR games today.</p>
+        </div>
+
+        <div data-feature="3D graphics">
+          <p>Within W3C, the <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a> is designing a new Web API to expose modern 3D graphics capabilities in a performant, powerful and safe manner, with a view to being agnostic of and compatible with existing native system platforms such as Direct3D, Metal, or Vulkan. Longer term, this proposal should also expose GPU computation capabilities to Web applications.</p>
+        </div>
+
+        <div data-feature="Rendering in workers">
+          <p>Web workers do not have access to the DOM and cannot directly render content on screen. The <a data-featureid="offscreencanvas"><code>OffscreenCanvas</code> interface</a> in HTML makes it possible to create rendering context with no connection to the DOM, and in particular to do that in workers.</p>
+        </div>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/storage.html
+++ b/games/storage.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>Data Storage</title>
+  </head>
+  <body>
+    <header>
+      <h1>Data Storage</h1>
+      <p>A critical component of many games is the ability to save state and game assets to speed up loading times and ensure continuity when the game is played offline.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+        <p data-feature="Simple data storage">For simple data storage, the <a data-featureid="webstorage">Web Storage</a> specification offers two basic mechanisms, <code>localStorage</code> and <code>sessionStorage</code>, that can preserve data respectively indefinitely, or on a browser-session basis.</p>
+
+        <p data-feature="Database query/update">The <a data-featureid="indexeddb">Indexed Database API</a> (IndexedDB) defines a database of values and hierarchical objects that integrates naturally with JavaScript, and can be queried and updated very efficiently - a <a href="https://w3c.github.io/IndexedDB/">third edition of the specification</a> is under development.</p>
+
+        <p data-feature="Encrypted storage">Some of the data may need to be encrypted, the <a data-featureid="crypto">Web Cryptography API</a> exposes strong cryptography primitives to Web applications, and can be bound to pre-provisioned keys via the <a data-featureid="cryptokey">WebCrypto Key Discovery</a> API.</p>
+
+        <p data-feature="File download">The <a data-featureid="html5-download">HTML5 <code>download</code> attribute</a> provides a simple mechanism to trigger a file download (rather than a page navigation), with the possibility of setting a user-friendly filename.</p>
+      </section>
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+
+        <div data-feature="File operations">
+          <p>The <a data-featureid="fileapi">File API</a> makes it possible to load the content of a file, for richer interactions with the file system. However, note discussions on a sandboxed filesystem API that could have allowed to write files onto a sandboxed file system have halted for lack of interest.</p>
+        </div>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+
+        <p data-feature="Quota for storage">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space. The proposed <a data-featureid="storage">Storage</a> specification will allow Web applications to get quota estimate for storage as well as to request that the data stored by the application be treated as persistent and cannot be evicted without the user’s explicit consent.</p>
+      </section>
+
+      <section>
+        <h2>Discontinued features</h2>
+        <dl>
+          <dt>Quota management API</dt>
+          <dd>Work on the <a data-featureid="quota">Quota Management API</a>, started in the Web Platform Working Group to expose an API to manage usage and availability of local storage resources, was discontinued in favor of the newer <a data-featureid="storage">Storage</a> proposal.</dd>
+
+          <dt>Client-side SQL-based database</dt>
+          <dd>The work around a <a data-featureid="websql">client-side SQL-based database</a>, which had been started in 2009, has been abandoned in favor of the work on IndexedDB.</dd>
+
+          <dt>Address book data</dt>
+          <dd>Communication applications can benefit from integrating with their users’ existing data records; on mobile devices, the address book is a particularly useful source of information. For Web apps outside of the browser, a purely programmatic approach was part of the <a href="https://www.w3.org/2012/05/sysapps-wg-charter.html">System Applications Working Group</a>; since this group has now closed, no further work on the <a data-featureid="contacts-sys">Contacts Manager API</a> is expected for the time being. Within the browser, HTML provides <a data-featureid="autocomplete">autocompleted fields for contacts information</a> that would let browsers re-use data from address books.</dd>
+        </dl>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/games/toc.json
+++ b/games/toc.json
@@ -1,0 +1,55 @@
+{
+  "title": "Games on the Web Roadmap",
+  "discourse": {
+    "category": "W3C’s discourse forum",
+    "url": "https://discourse.wicg.io/"
+  },
+  "github": "https://github.com/w3c/web-roadmaps",
+  "pages": [
+    {
+      "url": "performance.html",
+      "title": "Performance",
+      "icon": "../assets/img/media-processing.svg",
+      "description": "Mechanisms to harness available power (memory, computation, rendering)."
+    },
+    {
+      "url": "rendering.html",
+      "title": "Rendering",
+      "icon": "../assets/img/mobile-graphics.svg",
+      "description": "Features needed to render the game's user interface and audio environment."
+    },
+    {
+      "url": "userinput.html",
+      "title": "User Interaction",
+      "icon": "../assets/img/mobile-userinput.svg",
+      "description": "Features needed to engage the user through device-specific interaction mechanisms and guarantee the accessibility of these interactions."
+    },
+    {
+      "url": "network.html",
+      "title": "Network and Communications",
+      "icon": "../assets/img/mobile-network.svg",
+      "description": "Interactions with the network to fetch resources and communicate between peers, e.g. to enable multi-player games."
+    },
+    {
+      "url": "lifecycle.html",
+      "title": "Progressive Web Applications (PWA)",
+      "icon": "../assets/img/mobile-lifecycle.svg",
+      "description": "Mechanisms to integrate the application with the rest of the system and provide a native-like experience."
+    },
+    {
+      "url": "storage.html",
+      "title": "Data Storage",
+      "icon": "../assets/img/mobile-storage.svg",
+      "description": "Technologies available to save state and game assets."
+    },
+    {
+      "url": "payment.html",
+      "title": "Payment and Services",
+      "icon": "../assets/img/mobile-payment.svg",
+      "description": "Features needed to monetize a game, e.g. by integrating easy-to-use in-app purchases."
+    }
+  ],
+  "about": {
+    "url": "about.html"
+  }
+}

--- a/games/userinput.html
+++ b/games/userinput.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>User Interaction</title>
+  </head>
+  <body>
+    <header>
+      <h1>User Interaction</h1>
+      <p>By definition, games are interactive. That interactivity has taken the form of various game controllers over the years, including mouses and keyboards, touch screens, joysticks, gamepads, pointing devices, and dedicated objects such as guitars, wheels, or dance mat pads. Connected objects of all kinds that use Near-field Communications (NFC) or Bluetooth are also being used to make the game more tangible to players. Last but not least, various games and platforms are exploring natural interaction mechanisms&mdash;motion detection, voice interaction, eye tracking&mdash;to further bridge reality and fiction.</p>
+      <p>The Web platform tries to accommodate all these input devices. When possible, it tries to abstract away from the exact user input mechanism, both as a way to enable the use of new controllers with existing content, as well as to address accessibility issues that some controllers may raise.</p>
+    </header>
+    <main>
+      <section class="featureset well-deployed">
+        <h2>Well-deployed technologies</h2>
+        <div data-feature="Touch-based interactions">
+          <p>An increasing share of mobile devices relies on touch-based interactions. While the traditional interactions recognized in the Web platform (keyboard, mouse input) can still be applied in this context, a more specific handling of touch-based input is a critical aspect of creating well-adapted user experiences, which <a data-featureid="touchevent">Touch Events in the DOM</a> (Document Object Model) enable.</p>
+        </div>
+
+        <div data-feature="Sensors">
+          <p>The <a data-featureid="geolocation">Geolocation API</a> provides a common interface for locating the device, independently of the underlying technology (GPS, Wi-Fi networks identification, triangulation in cellular networks, etc.).</p>
+
+          <p>The <a data-featureid="deviceorientation">DeviceOrientation Event Specification</a> defines several DOM events that provide information about the physical orientation and motion of a hosting device. Most browsers support this specification, although various interoperability issues have arised. The work on the specification itself has been discontinued when the Geolocation Working Group was closed. The <a href="https://www.w3.org/das/">Devices and Sensors Working Group</a> is now chartered to reduce inconsistencies across implementations and finalize the specification accordingly, and develop the more powerful <a href="https://w3c.github.io/orientation-sensor/">Orientation Sensor</a> specification in parallel.</p>
+        </div>
+
+        <p data-feature="Vibration">The <a data-featureid="vibration">Vibration API</a> lets game developers take advantage of haptic feedback to create new forms of interactions.</p>
+
+        <div data-feature="Accessibility">
+          <p>The <a data-featureid="uaag20">User Agent Accessibility Guidelines (UAAG) 2.0</a> note defines principles and guidelines for user agents to design an accessible user agent interface and communicate with assistive technologies. The supporting document <a data-featureid="uaag20-reference">UAAG 2.0 Reference</a> explains the intent and best practices of UAAG 2.0 success criteria, and lists numerous examples for each of them.</p>
+          <p>Following the <a data-featureid="wcag21">Web Content Accessibility Guidelines (WCAG) 2.1</a> will make content accessible to a wider range of people with disabilities. The 2.1 revision adds new success criteria and guidelines to version 2.0, including new criteria related to user input that have a specific resonance in games, such as the <a href="https://www.w3.org/TR/WCAG21/#pointer-gestures">Pointer Gestures</a> and <a href="https://www.w3.org/TR/WCAG21/#target-size">Target Size</a> criteria.</p>
+          <p>Web content developers may benefit from authoring tools that follow the <a data-featureid="atag20">Authoring Tool Accessibility Guidelines (ATAG) 2.0</a> standard, which provides guidelines for designing Web content authoring tools that are both more accessible to authors with disabilities and that help design content that conforms to WCAG.</p>
+          <p>The <a data-featureid="wai-aria11">Accessible Rich Internet Applications (WAI-ARIA) 1.1</a> standard provides an ontology of roles, states, and properties that define the semantics of user interface elements and that can be used to improve the accessibility and interoperability of Web content and applications. The <a data-featureid="core-aam11">Core Accessibility API Mappings 1.1</a> standard describes how user agents should expose these semantics to accessibility APIs.</p>
+        </div>
+      </section>
+
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+
+        <div data-feature="Game controllers">
+          <p>The <a data-featureid="gamepad">Gamepad</a> specification defines a low-level interface that exposes gamepad devices attached to the browsing device.</p>
+          <p>The <a data-featureid="webxr">WebXR Device API</a> exposes VR/AR-specific input, including tracked controller state and hand gesture.</p>
+        </div>
+
+        <div data-feature="Touch-based interactions">
+          <p>The <a href="https://www.w3.org/2012/pointerevents/">Pointer Events Working Group</a> has made good progress on an alternative approach to handle user input, <a data-featureid="pointer-events">Pointer Events</a>, that allows to handle mouse, touch and pen events under a single model. It provides a complementary and more unified  approach to the currently more widely deployed Touch Events.</p>
+          <p>In particular, the <a data-featureid="css-touch-action">CSS property <code>touch-action</code></a> that lets filter gesture events on elements is gaining traction beyond implementations of Pointer Events.</p>
+          <p>The early proposal for an <a data-featureid="inputdevice">Input Device capabilities API</a> would provide information about whether a given “mouse” event comes from a touch-capable device.</p>
+        </div>
+
+        <div data-feature="Sensors">
+          <p>The <a data-featureid="generic-sensor">Generic Sensor API</a> defines a framework for exposing sensor data to the Web platform in a consistent way. In particular, the specification defines a blueprint for writing specifications of concrete sensors along with an abstract <code>Sensor</code> interface that can be extended to accommodate different sensor types.</p>
+
+          <p>A number of sensor APIs are being built on top of the Generic Sensor API. The <a data-featureid="proximity">Proximity Sensor</a> specification defines an API to monitor the presence of nearby objects without physical contact. The <a data-featureid="ambientlight">Ambient Light Sensor</a> specification defines an API to monitor the ambient light level or illuminance of the device's environment..</p>
+
+          <p>The detection of motion is made possible by a combination of low-level and high-level motion sensor specifications, also built on top of the Generic Sensor API:</p>
+
+          <ul>
+            <li>the <a data-featureid="accelerometer">Accelerometer</a> to obtain information about acceleration applied to the device's local three primary axes;</li>
+            <li>the <a data-featureid="gyroscope">Gyroscope</a> to monitor the rate of rotation around the device's local three primary axes;</li>
+            <li>the <a data-featureid="magnetometer">Magnetometer</a> to measure magnetic field around the device's local three primary axes;</li>
+            <li>the <a data-featureid="orientation">Orientation Sensor</a> to monitor the device's physical orientation in relation to a stationary 3D Cartesian coordinate system.</li>
+          </ul>
+
+          <p>The <a href="https://www.w3.org/TR/motion-sensors/">Motion Sensors Explainer</a> document is an introduction to low-level and high-level motion sensors, their relationship, inner workings and common use-cases.</p>
+
+          <p>The <a data-featureid="geolocation-sensor">Geolocation Sensor</a> is an API for obtaining geolocation reading from the hosting device. The feature set of the Geolocation Sensor is similar to that of the Geolocation API, but it is surfaced through the Generic Sensor API, improves security and privacy, and is extensible.</p>
+        </div>
+
+        <div data-feature="Screen wake lock">
+          <p>Whether players are speaking commands to the game or interacting with them through non-haptic mechanisms, they risk seeing the screens turned off automatically by their devices screensaver. The <a data-featureid="wake-lock">Wake Lock API</a> lets developers signal the needs to keep the screen up in these circumstances.</p>
+        </div>
+      </section>
+
+      <section class="featureset exploratory-work">
+        <h2>Exploratory work</h2>
+
+        <div data-feature="Interactions with physical objects">
+          <p>Games may want the user to interact with physical objects to improve the experience. The <a href="http://w3c.github.io/web-nfc/" data-featureid="webnfc">Web Near-Field Communications (NFC) API</a> enables wireless communication between two devices at close proximity. Similarly, the <a data-featureid="webbluetooth">Web Bluetooth</a> specification describes an API to discover and communicate with devices over the Bluetooth Low Energy (BLE) mode.</p>
+        </div>
+
+        <p data-feature="Speech-based interactions">Mobile devices are also in many cases well-suited to be used through voice-interactions; the <a href="https://www.w3.org/community/speech-api/">Speech API Community Group</a> developed a JavaScript API to enable interactions with a Web page through spoken commands. <a data-featureid="speech-api/synthesis">Speech synthesis</a> is well supported across browsers. Support for <a data-featureid="speech-api/recognition">speech recognition</a> is still underway.</p>
+
+        <p data-feature="Input method">The <a data-featureid="ime-api">Input Method Editor (IME) API</a> provides Web applications with scripted access to an IME (input-method editor) associated with a hosting user agent. Editorial support is required for this specification to move forward.</p>
+      </section>
+
+      <section>
+        <h2>Features not covered by ongoing work</h2>
+        <dl>
+          <dt>Gesture events</dt>
+          <dd>As mentioned above, touch-based interaction is common on mobile devices and available to Web applications through <a data-featureid="touchevent">Touch events</a>. <strong>Gesture-based interaction</strong>, which includes pinching, rotating and swiping, is also a common interaction paradigm on mobile devices. Web developers may derive gesture events from touch events to some extent, but may have to develop multiple versions for different browsers. Native support for these interactions would reduce fragmentation and improve performance. Early discussions to define <a href="https://github.com/JuntaoPeng/GestureEvents/blob/master/GestureEvents.md#gesture-events">Gesture events</a> have started in the <a href="https://www.w3.org/community/mwma/">Merging of Web and Mobile APP Community Group</a>.</dd>
+        </dl>
+      </section>
+
+      <section>
+        <h2>Discontinued features</h2>
+        <dl>
+          <dt>Intent-based events</dt>
+          <dd>As the Web reaches new devices, and as devices gain new user interactions mechanisms, it seems useful to allow Web developers to react to a more abstract set of user interactions: instead of having to work in terms of “click”, “key press”, or “touch event”, being able to react to an “undo” command, or a “next page” command independently of how the user instructed it to the device. The <a data-featureid="indie-ui-events">IndieUI Events</a> specification was an attempt to address this need. The work has been discontinued for now, due to lack of support from would-be implementers.</dd>
+        </dl>
+      </section>
+    </main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -87,6 +87,11 @@ const publishers = {
     label: 'International Organization for Standardization (ISO)',
     url: 'https://www.iso.org/',
     urlPattern: 'iso.org'
+  },
+  'Khronos': {
+    label: 'Khronos Group',
+    url: 'https://www.khronos.org/',
+    urlPattern: 'www.khronos.org/registry/'
   }
 };
 


### PR DESCRIPTION
The roadmap reuses a lot of the material from the mobile roadmap and icons from the media and mobile roadmaps too. Content has been adapted to games though:
- Many technologies have been dropped to focus on those that are more directly relevant for games.
- A couple of technologies have been added, including the new Web Locks API proposal.
- Descriptions have also been updated to talk about technologies in the context of games.