### PR TITLE
Generate group info automatically from publisher when possible

### DIFF
--- a/data/element-queries.json
+++ b/data/element-queries.json
@@ -1,10 +1,4 @@
 {
   "url": "https://wicg.github.io/cq-usecases/",
-  "title": "Element Queries",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ]
+  "title": "Element Queries"
 }

--- a/data/event-timing.json
+++ b/data/event-timing.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/event-timing/",
   "title": "Event Timing API",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "impl": {
     "chromestatus": 5167290693713920
   }

--- a/data/fetch.json
+++ b/data/fetch.json
@@ -1,12 +1,6 @@
 {
   "url": "https://fetch.spec.whatwg.org/",
   "title": "Fetch",
-  "wgs": [
-    {
-      "label": "WHATWG",
-      "url": "https://whatwg.org/"
-    }
-  ],
   "impl": {
     "caniuse": "fetch",
     "chromestatus": 6730533392351232,

--- a/data/fullscreen.json
+++ b/data/fullscreen.json
@@ -1,12 +1,6 @@
 {
   "url": "https://fullscreen.spec.whatwg.org/",
   "title": "Fullscreen API",
-  "wgs": [
-    {
-      "label": "WHATWG",
-      "url": "https://whatwg.org/"
-    }
-  ],
   "impl": {
     "caniuse": "fullscreen",
     "chromestatus": 5259513871466496,

--- a/data/mse-v2.json
+++ b/data/mse-v2.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/media-source/",
   "title": "Media Source Extensions™",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "features": {
     "codec-switching": {
       "title": "Codec switching",

--- a/data/permissions-request.json
+++ b/data/permissions-request.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/permissions-request/",
   "title": "Requesting Permissions",
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ],
   "impl": {
     "chromestatus": 5707368532803584
   }

--- a/data/permissions-revoke.json
+++ b/data/permissions-revoke.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/permissions-revoke/",
   "title": "Relinquishing Permissions",
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ],
   "impl": {
     "chromestatus": 5707368532803584
   }

--- a/data/priority-hints.json
+++ b/data/priority-hints.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/priority-hints/",
   "title": "Priority Hints",
-  "wgs": [
-    {
-      "label": "Web Platform Incubator Community Group",
-      "url": "https://www.w3.org/community/wicg/"
-    }
-  ],
   "impl": {
     "chromestatus": 5273474901737472
   }

--- a/data/storage.json
+++ b/data/storage.json
@@ -1,12 +1,6 @@
 {
   "url": "https://storage.spec.whatwg.org/",
   "title": "Storage",
-  "wgs": [
-    {
-      "label": "WHATWG",
-      "url": "https://whatwg.org/"
-    }
-  ],
   "impl": {
     "mdn": "api.StorageManager"
   },

--- a/data/streams.json
+++ b/data/streams.json
@@ -1,12 +1,6 @@
 {
   "url": "https://streams.spec.whatwg.org/",
   "title": "Streams",
-  "wgs": [
-    {
-      "label": "WHATWG",
-      "url": "https://whatwg.org/"
-    }
-  ],
   "impl": {
     "caniuse": "streams",
     "chromestatus": 6605041225957376,

--- a/data/xhr.json
+++ b/data/xhr.json
@@ -1,12 +1,6 @@
 {
   "url": "https://xhr.spec.whatwg.org/",
   "title": "XMLHttpRequest",
-  "wgs": [
-    {
-      "label": "WHATWG",
-      "url": "https://whatwg.org/"
-    }
-  ],
   "impl": {
     "caniuse": "xhr2"
   }

--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -47,9 +47,6 @@ const maturityMapping = {
 
 /**
  * Well-known publishers and URL pattern of the specs they publish
- * (Note the w3c.github.io is not restricted to WICG in practice, but the
- * code associates a WICG spec with W3C in any case, so that's good enough
- * for now and avoids having to handle arrays of patterns)
  */
 const publishers = {
   'W3C': {
@@ -57,10 +54,17 @@ const publishers = {
     url: 'https://www.w3.org/',
     urlPattern: '.w3.org'
   },
+  'W3C-ED': {
+    label: 'W3C',
+    url: 'https://www.w3.org/',
+    urlPattern: 'w3c.github.io',
+    parentPublisher: 'W3C'
+  },
   'WHATWG': {
     label: 'WHATWG',
     url: 'https://whatwg.org',
-    urlPattern: '.spec.whatwg.org'
+    urlPattern: '.spec.whatwg.org',
+    isGroup: true
   },
   'IETF': {
     label: 'IETF',
@@ -70,8 +74,9 @@ const publishers = {
   'WICG': {
     label: 'Web Platform Incubator Community Group',
     url: 'https://www.w3.org/community/wicg/',
-    urlPattern: 'w3c.github.io',
-    parentPublisher: 'W3C'
+    urlPattern: 'wicg.github.io',
+    parentPublisher: 'W3C',
+    isGroup: true
   },
   'OGC': {
     label: 'Open Geospatial Consortium',
@@ -91,7 +96,8 @@ const publishers = {
   'Khronos': {
     label: 'Khronos Group',
     url: 'https://www.khronos.org/',
-    urlPattern: 'www.khronos.org/registry/'
+    urlPattern: 'www.khronos.org/registry/',
+    isGroup: true
   }
 };
 
@@ -439,10 +445,6 @@ async function extractSpecData(files, config) {
         return { url: group.url, label };
       });
     }
-    else if (info.publisher && (info.publisher in publishers)) {
-      let publisher = publishers[info.publisher];
-      info.deliveredBy = [{ url: publisher.url, label: publisher.label }];
-    }
     if (!info.deliveredBy) {
       info.deliveredBy = [];
     }
@@ -471,6 +473,15 @@ async function extractSpecData(files, config) {
       }
       if (!info.publisher) {
         console.warn(`- ${spec.id}: No publisher found`);
+      }
+    }
+
+    // Some publishers are the actual groups that delivered the spec
+    if (info.publisher && (info.publisher in publishers) &&
+        (info.deliveredBy.length === 0)) {
+      let publisher = publishers[info.publisher];
+      if (publisher.isGroup) {
+        info.deliveredBy = [{ url: publisher.url, label: publisher.label}];
       }
     }
 


### PR DESCRIPTION
The spec info generation tool did not properly populate the `deliveredBy` property from the publisher info. It either failed to do so, or actually populated the property with the publisher's info even though the publisher was not a group (e.g. OGC is not a group, it's a consortium made of groups).

See https://github.com/w3c/web-roadmaps/pull/342#pullrequestreview-183114990