### PR TITLE
[Mobile] Mention Badging API

### DIFF
--- a/data/badging.json
+++ b/data/badging.json
@@ -1,12 +1,6 @@
 {
   "url": "https://wicg.github.io/badging/",
   "title": "Badging API",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ],
   "impl": {
     "chromestatus": 6068482055602176
   }

--- a/data/badging.json
+++ b/data/badging.json
@@ -1,0 +1,13 @@
+{
+  "url": "https://wicg.github.io/badging/",
+  "title": "Badging API",
+  "wgs": [
+    {
+      "url": "https://www.w3.org/community/wicg/",
+      "label": "Web Platform Incubator Community Group"
+    }
+  ],
+  "impl": {
+    "chromestatus": 6068482055602176
+  }
+}

--- a/mobile/lifecycle.html
+++ b/mobile/lifecycle.html
@@ -46,6 +46,7 @@
 
         <div data-feature="Packing">
           <p>The <a data-featureid="packaging">Web Packaging</a> document describes use cases for a new package format for web sites and applications and outlines such a format.</p>
+          <p>The <a data-featureid="badging">Badging API</a> defines a more subtle notification mechanism than <a href="https://www.w3.org/TR/notifications/">Web Notifications</a>, allowing Web applications that have been installed on the device (e.g. through a manifest file) to set an application-wide badge, typically shown next to the application's icon on the home screen, to notify the user when the state of the application has changed and might require their attention (e.g. a new message has arrived).</p>
         </div>
 
         <div data-feature="State transition">

--- a/mobile/userinput.html
+++ b/mobile/userinput.html
@@ -59,6 +59,10 @@
         <div data-feature="Touch-based interactions">
           <p>The proposal for an <a data-featureid="inputdevice">Input Device capabilities API</a> would provide information about whether a given “mouse” event comes from a touch-capable device.</p>
         </div>
+
+        <div data-feature="Notification">
+          <p>The <a data-featureid="badging">Badging API</a> defines a more subtle notification mechanism than <a href="https://www.w3.org/TR/notifications/">Web Notifications</a>, allowing Web applications that have been installed on the device (e.g. through a manifest file) to set an application-wide badge, typically shown next to the application's icon on the home screen, to notify the user when the state of the application has changed and might require their attention (e.g. a new message has arrived).</p>
+        </div>
       </section>
 
       <section>


### PR DESCRIPTION
Spec mentioned both in Application lifecycle as part of packaging, and in User interaction as part of the discussion on notifications.

Fix #326