### PR TITLE
[Framework] Associate "github.com/WICG/" URLs with WICG

### DIFF
--- a/data/packaging.json
+++ b/data/packaging.json
@@ -1,10 +1,4 @@
 {
   "url": "https://github.com/WICG/webpackage",
-  "title": "Web Packaging",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ]
+  "title": "Web Packaging"
 }

--- a/data/spatial-navigation.json
+++ b/data/spatial-navigation.json
@@ -1,10 +1,4 @@
 {
   "url": "https://github.com/WICG/spatial-navigation",
-  "title": "Spatial Navigation",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/wicg/",
-      "label": "Web Platform Incubator Community Group"
-    }
-  ]
+  "title": "Spatial Navigation"
 }

--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -52,58 +52,45 @@ const publishers = {
   'W3C': {
     label: 'W3C',
     url: 'https://www.w3.org/',
-    urlPattern: '.w3.org'
-  },
-  'W3C-ED': {
-    label: 'W3C',
-    url: 'https://www.w3.org/',
-    urlPattern: 'w3c.github.io',
-    parentPublisher: 'W3C'
+    urlPattern: /\.w3\.org|w3c\.github\.io/i
   },
   'WHATWG': {
     label: 'WHATWG',
     url: 'https://whatwg.org',
-    urlPattern: '.spec.whatwg.org',
+    urlPattern: /\.spec\.whatwg\.org/i,
     isGroup: true
   },
   'IETF': {
     label: 'IETF',
     url: 'https://ietf.org',
-    urlPattern: '.ietf.org'
+    urlPattern: /\.ietf\.org/i
   },
   'WICG': {
     label: 'Web Platform Incubator Community Group',
     url: 'https://www.w3.org/community/wicg/',
-    urlPattern: 'wicg.github.io',
-    parentPublisher: 'W3C',
-    isGroup: true
-  },
-  'WICG-EXPLAINER': {
-    label: 'Web Platform Incubator Community Group',
-    url: 'https://www.w3.org/community/wicg/',
-    urlPattern: 'github.com/WICG/',
+    urlPattern: /wicg\.github\.io|github\.com\/wicg\//i,
     parentPublisher: 'W3C',
     isGroup: true
   },
   'OGC': {
     label: 'Open Geospatial Consortium',
     url: 'http://www.opengeospatial.org/',
-    urlPattern: 'opengeospatial.org'
+    urlPattern: /opengeospatial\.org/i
   },
   'EC': {
     label: 'European Commission',
     url: 'http://data.europa.eu/euodp/en/home',
-    urlPattern: 'data.europa.eu'
+    urlPattern: /data\.europa\.eu/i
   },
   'ISO': {
     label: 'International Organization for Standardization (ISO)',
     url: 'https://www.iso.org/',
-    urlPattern: 'iso.org'
+    urlPattern: /iso\.org/i
   },
   'Khronos': {
     label: 'Khronos Group',
     url: 'https://www.khronos.org/',
-    urlPattern: 'www.khronos.org/registry/',
+    urlPattern: /www\.khronos\.org\/registry\//i,
     isGroup: true
   }
 };
@@ -472,11 +459,11 @@ async function extractSpecData(files, config) {
       if (info.deliveredBy && (info.deliveredBy.length > 0)) {
         let groupUrl = info.deliveredBy[0].url || '';
         info.publisher = Object.keys(publishers)
-          .find(id => groupUrl.includes(publishers[id].urlPattern));
+          .find(id => !!groupUrl.match(publishers[id].urlPattern));
       }
       if (!info.publisher && info.url) {
         info.publisher = Object.keys(publishers)
-          .find(id => info.url.includes(publishers[id].urlPattern));
+          .find(id => !!info.url.match(publishers[id].urlPattern));
       }
       if (!info.publisher) {
         console.warn(`- ${spec.id}: No publisher found`);

--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -78,6 +78,13 @@ const publishers = {
     parentPublisher: 'W3C',
     isGroup: true
   },
+  'WICG-EXPLAINER': {
+    label: 'Web Platform Incubator Community Group',
+    url: 'https://www.w3.org/community/wicg/',
+    urlPattern: 'github.com/WICG/',
+    parentPublisher: 'W3C',
+    isGroup: true
+  },
   'OGC': {
     label: 'Open Geospatial Consortium',
     url: 'http://www.opengeospatial.org/',


### PR DESCRIPTION
Early proposals in WICG may have an explainer published on `github.com/WICG/`
but no draft spec published on `wicg.github.io`. The code now correctly
associates explainer URLs with WICG.

Fix #348.