### PR TITLE
[Mobile] Mention Writable Files

### DIFF
--- a/data/writable-files.json
+++ b/data/writable-files.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://wicg.github.io/writable-files/",
+  "title": "Writable Files",
+  "impl": {
+    "chromestatus": 6284708426022912
+  }
+}

--- a/mobile/storage.html
+++ b/mobile/storage.html
@@ -24,7 +24,7 @@
         <h2>Technologies in progress</h2>
 
         <div data-feature="File operations">
-          <p>The <a data-featureid="fileapi">File API</a> makes it possible to load the content of a file, for richer interactions with the file system. However, note discussions on a sandboxed filesystem API that could have allowed to write files onto a sandboxed file system have halted for lack of interest.</p>
+          <p>Although the notion is less prevalent on mobile, there is generally at least some sort of concept of a file system. The <a data-featureid="fileapi">File API</a> provides an API for representing file objects in web applications, as well as programmatically selecting them and accessing their data. The API is read-only. Discussions on a read-write API have now resumed, see <a href="#writable-files">Writable Files</a> below.</p>
         </div>
       </section>
 
@@ -32,6 +32,10 @@
         <h2>Exploratory work</h2>
 
         <p data-feature="Quota for storage">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space. The proposed <a data-featureid="storage">Storage</a> specification will allow Web applications to get quota estimate for storage as well as to request that the data stored by the application be treated as persistent and cannot be evicted without the user’s explicit consent.</p>
+
+        <div data-feature="File operations">
+          <p>The <a data-featureid="writable-files">Writable Files</a> specification is an early API proposal that lets Websites gain write access to the native file system. It builds on top of the <a href="#fileapi">File API</a>.</p>
+        </div>
       </section>
 
       <section>


### PR DESCRIPTION
The File API and Writable Files specifications are probably not the ones that have the strongest impact on mobile, but they should remain useful there too, and the roadmap already mentioned the File API.

The description of the File API now provides more context, and refers to Writable Files for the read-write API.

Fix #324