### PR TITLE
[Data] Refresh spec URLs

### DIFF
--- a/data/css-page-3.json
+++ b/data/css-page-3.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.w3.org/TR/css3-page/",
+  "url": "https://www.w3.org/TR/css-page-3/",
   "impl": {
     "caniuse": "css-paged-media"
   }

--- a/data/user-timing.json
+++ b/data/user-timing.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.w3.org/TR/user-timing/",
+  "url": "https://www.w3.org/TR/user-timing-2/",
   "impl": {
     "caniuse": "user-timing",
     "chromestatus": 5066549580791808,

--- a/data/webauthn.json
+++ b/data/webauthn.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://www.w3.org/TR/webauthn/",
+  "url": "https://www.w3.org/TR/webauthn-1/",
   "impl": {
     "caniuse": "webauthn",
     "chromestatus": 5669923372138496,

--- a/publishing/CSS.html
+++ b/publishing/CSS.html
@@ -18,7 +18,7 @@
                 </li>
 
                 <li>
-                    The <span data-feature="CSS Page 3"><a data-featureid="css3-page">CSS Page 3</a></span> modules specifies how pages are generated and laid out to hold fragmented content in a paged presentation. It adds functionality for controlling page margins, page size and orientation, and headers and footers, bleed and printer marks, and extends generated content to enable page numbering and running headers/footers. It may become necessary, however, to extend the <code>@page</code> feature to express initial preference over scrolling vs. pagination. 
+                    The <span data-feature="CSS Page 3"><a data-featureid="css-page-3">CSS Page 3</a></span> modules specifies how pages are generated and laid out to hold fragmented content in a paged presentation. It adds functionality for controlling page margins, page size and orientation, and headers and footers, bleed and printer marks, and extends generated content to enable page numbering and running headers/footers. It may become necessary, however, to extend the <code>@page</code> feature to express initial preference over scrolling vs. pagination. 
                 </li>
 
                 <li data-feature="CSS Device Adaptation">


### PR DESCRIPTION
A few specs have switched to versioning, with the canonical /TR/ URL now being an alias for a real shortname with a version. The W3C API does not return anything about aliases, so we need to track the versioned URL.