### PR TITLE
[Mobile] Mention Clipboard API and Events

### DIFF
--- a/data/clipboard-apis.json
+++ b/data/clipboard-apis.json
@@ -1,0 +1,6 @@
+{
+  "url": "https://www.w3.org/TR/clipboard-apis/",
+  "impl": {
+    "chromestatus": 5861289330999296
+  }
+}

--- a/mobile/forms.html
+++ b/mobile/forms.html
@@ -23,6 +23,13 @@
         <p data-feature="Form autocomplete">The <code><a data-featureid="datalist">&lt;datalist&gt;</a></code> element allows creating free-text input controls coming with <strong>pre-defined values</strong> the user can select from; the <a data-featureid="autocomplete"><code>autocomplete</code> attribute</a> is a mechanism to automatically fill input fields based on <strong>well-known data</strong> for the user, solving the problem of working with long and multi-page forms that are common on mobile devices, e.g. in mobile purchase scenarios.</p>
       </section>
 
+      <section class="featureset in-progress">
+        <h2>Technologies in progress</h2>
+        <div data-feature="Clipboard">
+          <p>Copy and paste operations are a core mechanism to pass text input from one application to another, especially on devices where text input remains a challenge. The <a data-featureid="clipboard-apis">Clipboard API and events</a> specification describe APIs for overriding the default clipboard actions (e.g. to add metadata or to reformat the content), and for directly accessing the clipboard contents (e.g. to keep clipboard data in sync between a local app that communicates with a remote device).</p>
+        </div>
+      </section>
+
       <section>
         <h2>Discontinued features</h2>
         <dl>


### PR DESCRIPTION
The update creates a "Technologies in progress" section in the "Forms" page to mention the specification. Given that the spec is about optimizing user input, this seems a better choice than the "User interaction" page, which is about device-spcific interaction mechanisms.

Fixes #375.