### PR TITLE
[mobile] Move Media Capture and Streams to well-deployed in sensors

### DIFF
--- a/mobile/sensors.html
+++ b/mobile/sensors.html
@@ -16,6 +16,10 @@
         <div data-feature="Geolocation">
           <p>The <a data-featureid="geolocation">Geolocation API</a> provides a common interface for locating the device, independently of the underlying technology (GPS, Wi-Fi networks identification, triangulation in cellular networks, etc.).</p>
         </div>
+
+        <div data-feature="Camera &amp; Microphone streams">
+          <p>As detailed in the <a href="media.html">Media</a> part of this document, the <a data-featureid="getusermedia">Media Capture and Streams API</a> opens up access to camera and microphone streams.</p>
+        </div>
       </section>
 
       <section class="featureset in-progress">
@@ -47,8 +51,6 @@
 
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
-
-        <p data-feature="Camera &amp; Microphone streams">As detailed in the <a href="media.html">Media</a> part of this document, there is ongoing work on <a data-featureid="getusermedia">APIs to open up access to camera and microphone</a> streams.</p>
 
         <p data-feature="NFC">Work on a <a href="http://w3c.github.io/web-nfc/" data-featureid="webnfc">Web Near-Field Communications (NFC) API</a> to enable wireless communication between two devices at close proximity has started in the <a href="https://www.w3.org/community/web-nfc/">Web NFC Community Group</a>.</p>
 


### PR DESCRIPTION
Although still in CR, the specification appears in the well-deployed section of
the Media page already, so we should be consistent across pages.