### PR TITLE
[mobile] Move Web Authentication to well-deployed technologies

### DIFF
--- a/mobile/about.html
+++ b/mobile/about.html
@@ -38,6 +38,7 @@
             <dt>Well-deployed technologies</dt>
             <dd><ul>
               <li>Move Media Capture and Streams to well-deployed technologies in <a data-page="sensors"></a></li>
+              <li>Move Web Authentication to well-deployed technologies in <a data-page="security"></a></li>
             </ul></dd>
 
             <dt>Discontinued features</dt>

--- a/mobile/about.zh.html
+++ b/mobile/about.zh.html
@@ -38,6 +38,7 @@
             <dt>广泛部署的技术</dt>
             <dd><ul>
               <li>在<a data-page="sensors"></a>中将媒体捕捉与媒体流标为广泛部署的技术</li>
+              <li>在<a data-page="security"></a>中将Web认证标为广泛部署的技术</li>
             </ul></dd>
 
             <dt>不再进行的工作</dt>

--- a/mobile/security.html
+++ b/mobile/security.html
@@ -33,6 +33,10 @@
         <div data-feature="Encryption">
           <p>The <a data-featureid="crypto">Web Cryptography API</a> provides the necessary tools to encrypt data for storage and transmission from within Web applications, with access to pre-provisioned keys via the <a data-featureid="cryptokey">WebCrypto Key Discovery</a> API.</p>
         </div>
+
+        <div data-feature="Authentication">
+          <p>Building on the passwordless and multi-factor authentication work of the FIDO Alliance, <a data-featureid="webauthn">Web Authentication</a> standardizes strong authentication for the Web, using a combination of "something you have" (e.g. an authentication key) coupled with "something you know" (e.g. a PIN code) and/or "something you are" (e.g. a fingerprint), so that hacking a password database is no longer sufficient to hijack user accounts.</p>
+        </div>
       </section>
 
       <section class="featureset in-progress">
@@ -45,8 +49,6 @@
         <div data-feature="Identity Management">
           <p>To facilitate the authentication of users to on-line services, the <a href="https://www.w3.org/2011/webappsec/">Web Application Security Working Group</a> is proposing a <a data-featureid="credential-management">Credential Management API</a> that lets developers interact more seamless with user-agent-managed credentials.</p>
         </div>
-
-        <p data-feature="Authentication">Building on the passwordless and multi-factor authentication work of the FIDO Alliance, <a data-featureid="webauthn">Web Authentication</a> aims to standardize strong authentication for the Web, using a combination of "something you have" (e.g. an authentication key) coupled with "something you know" (e.g. a PIN code) and/or "something you are" (e.g. a fingerprint), so that hacking a password database is no longer sufficient to hijack user accounts.</p>
 
         <p data-feature="Secure contexts"><a data-featureid="securecontexts">Secure Contexts</a> recommends that powerful features of the Web platform, including application code with access to sensitive or private data, be delivered only in secure contexts, over authenticated and confidential channels that guarantee data integrity. As the draft indicates, "delivering code securely cannot ensure that an application will always meet a user's security and privacy requirements, but it is a necessary precondition."</p>
 

--- a/mobile/security.zh.html
+++ b/mobile/security.zh.html
@@ -34,6 +34,10 @@
         <div data-feature="加密">
           <p>通过<a data-featureid="cryptokey">WebCrypto密钥发现</a>API访问预先配置的密钥，<a data-featureid="crypto">Web密码学API</a>提供必要的工具来加密数据，以便在Web应用中进行存储和传输。</p>
         </div>
+        
+        <div data-feature="认证">
+          <p>基于 FIDO 联盟的免密和多因素认证工作，<a data-featureid="webauthn">Web认证</a>标准化了 Web 的强认证技术，使用“你拥有的东西”（如身份验证器）、“你知道的东西”（如PIN码）和“你是谁”（如指纹）的任意组合，让黑客即使窃取密码数据库也不足以劫持用户帐户。</p>
+        </div>
       </section>
 
       <section class="featureset in-progress">
@@ -46,8 +50,6 @@
         <div data-feature="身份管理">
           <p>为了方便用户对在线服务的认证，Web应用安全工作组提出了<a data-featureid="credential-management">信任证管理 API</a>，使开发人员能够与用户代理管理的凭证更加无缝地交互。</p>
         </div>
-
-        <p data-feature="认证">基于 FIDO 联盟的免密和多因素认证工作，<a data-featureid="webauthn">Web认证</a>的目标是使 Web 的强认证技术标准化，使用“你拥有的东西”（如身份验证器）、“你知道的东西”（如PIN码）和“你是谁”（如指纹）的任意组合，让黑客即使窃取密码数据库也不足以劫持用户帐户。</p>
 
         <p data-feature="安全上下文"><a data-featureid="securecontexts">安全上下文</a>建议 Web 平台的强大特性（包括访问敏感数据或私有数据的应用程序代码）只能在安全上下文中通过经过身份验证和加密的渠道传输，以此保证数据的完整性。草案指出：“安全地交付代码不能确保应用程序总是能够满足用户的安全和隐私要求，但这是一个必要的先决条件。”</p>
 


### PR DESCRIPTION
Spec not yet supported in Safari but it is supported elsewhere and it has been published as a W3C Recommendation early March.

@xfq Text slightly updated to drop "aims to" in "aims to standardize".