### PR TITLE
[data] Update implementation status for WebXR

### DIFF
--- a/data/webxr.json
+++ b/data/webxr.json
@@ -8,8 +8,9 @@
     }
   ],
   "impl": {
-    "caniuse": "webvr",
-    "chromestatus": 5680169905815552
+    "caniuse": "webxr",
+    "chromestatus": 5680169905815552,
+    "mdn": "api.XR"
   },
   "polyfills": [
     {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "ajv-cli": "^3.0.0",
     "fetch-filecache-for-crawling": "^3.0.2",
     "jsdom": "^11.8.0",
-    "mdn-browser-compat-data": "^0.0.39",
+    "mdn-browser-compat-data": "^0.0.92",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0"
   },


### PR DESCRIPTION
Implementation status was for previous WebVR spec. New implementation status
is more aligned with the WebXR spec.

Also update browser-compat-data version in package.json to retrieve the latest
0.0.x version (latest version was not used otherwise)