### PR TITLE
[mobile] Properly mention WebGL and WebGPU in Graphics

### DIFF
--- a/data/webgpu.json
+++ b/data/webgpu.json
@@ -1,0 +1,13 @@
+{
+  "url": "https://gpuweb.github.io/gpuweb/",
+  "title": "WebGPU",
+  "wgs": [
+    {
+      "url": "https://www.w3.org/community/wicg/",
+      "label": "Web Platform Incubator Community Group"
+    }
+  ],
+  "impl": {
+    "chromestatus": 6213121689518080
+  }
+}

--- a/mobile/graphics.html
+++ b/mobile/graphics.html
@@ -31,9 +31,11 @@
           <p><a data-featureid="svg11">SVG</a>, Scalable Vector Graphics, provides an XML-based markup language to describe two-dimensions vector graphics. Since these graphics are described as a set of geometric shapes, they can be zoomed at the user request, which makes them well-suited to create graphics on mobile devices where screen space is limited. They can also be easily animated, enabling the creation of very advanced and slick user interfaces.</p>
           <p>The integration of SVG in HTML5 opens up new possibilities, for instance applying advanced graphic filters (through SVG filters) to multimedia content, including videos. <a data-featureid="svg2">SVG 2</a> is set to facilitate that integration and complete the set of features in SVG.</p>
         </div>
-        <p data-feature="2D Programmatic API">In complement to the declarative approach provided by SVG, the <strong><code>&lt;canvas&gt;</code></strong> element added in HTML5 enables a <a data-featureid="canvas">2D programmatic API</a> that is well-suited for processing graphics in a less memory intensive way.</p>
+        <div data-feature="Graphics API">
+          <p>In complement to the declarative approach provided by SVG, the <strong><code>&lt;canvas&gt;</code></strong> element added in HTML5 enables a <a data-featureid="canvas">2D programmatic API</a> that is well-suited for processing graphics in a less memory intensive way.</p>
+          <p>Similarly, <a data-featureid="webgl">WebGL</a>, developed outside of W3C as part of the <a href="https://www.khronos.org/">Khronos Group</a>, provides a low-level 3D graphics API for the Web. This API has been built to be compatible with <a href="https://www.khronos.org/opengles/">OpenGL ES</a>, i.e. for embedded systems, and is intended to work on mobile devices. In practice, WebGL v1.0, based on OpenGL ES 2.0, is well supported across devices. Support for WebGL v2.0, based on OpenGL ES 3.0, is less pervasive. Work on a newer WebGPU API is ongoing, see the <a href="#exploratory-work">Exploratory work</a> section below.</p>
+        </div>
         <p>Another important aspect in graphics-intensive applications (e.g. games) is the possibility to use the entire screen to display the said graphics; the work on a <a data-featureid="fullscreen">Fullscreen API</a> to request and detect full screen display, now done in the <a href="https://whatwg.org/">WHATWG</a>.</p>
-        <p><strong>NB:</strong> a <a href="https://www.khronos.org/webgl/">3D graphic API for HTML5 <code>canvas</code>, called WebGL</a>, has been developed outside of W3C, as part of the <a href="https://www.khronos.org/">Khronos Group</a>; this API has been built to be compatible with <a href="https://www.khronos.org/opengles/">OpenGL ES</a>, i.e. for embedded systems, and is intended to work on mobile devices. The <a href="https://www.w3.org/community/gpu/">GPU for the Web Community Group</a> also started to design a new Web API to expose modern 3D graphics and computation capabilities in a performant, powerful and safe manner, with a goal to be agnostic of and compatible with existing native system platforms (such as Direct3D, Metal, or Vulkan).</p>
       </section>
       <section class="featureset in-progress">
         <h2>Technologies in progress</h2>
@@ -55,6 +57,10 @@
         <h2>Exploratory work</h2>
         <div data-feature="Animations">
           <p>Content rarely fits on screen on mobile devices, requiring users to scroll down. Applications may want to adjust their user interface based on the current scroll position, for example to shrink the top navigation menu as the user starts scrolling or to display a progress bar. This requires scripting for now. The <a data-featureid="scroll-animations">Scroll-linked Animations</a> specification proposes a declarative mechanism based on CSS properties.</p>
+        </div>
+
+        <div data-feature="Graphics API">
+          <p>The GPU for the Web Community Group has started to design the <a data-featureid="webgpu">WebGPU</a> API, a new Web API to expose modern 3D graphics and computation capabilities in a performant, powerful and safe manner, with a goal to be agnostic of and compatible with existing native system platforms (such as Direct3D, Metal, or Vulkan).</p>
         </div>
       </section>
     </main>


### PR DESCRIPTION
Mentions of WebGL and WebGPU were in a note and did not trigger the creation of entries in the implementation table. The text in Well-deployed technologies now properly references the WebGL spec and makes it clear that the implementation info is for version 1.0. It also links to the Exploratory work section that now links to the WebGPU draft.

Note I didn't add a second entry point for WebGL version 2.0 for now, that does not seem necessary.