### PR TITLE
[media] Update interoperability page title and description in TOC

### DIFF
--- a/media/toc.json
+++ b/media/toc.json
@@ -44,9 +44,9 @@
     },
     {
       "url": "apps.html",
-      "title": "Media application development",
+      "title": "Device interoperability",
       "icon": "../assets/img/media-app.svg",
-      "description": "Platform features and best practices to develop media applications on the Web"
+      "description": "Technologies and guidelines to reduce fragmentation across media devices."
     }
   ],
   "about": {


### PR DESCRIPTION
In a recent commit, the "Media application development" page was renamed into "Device interoperability". However, the table of contents file that describes the menu on the home page had not been updated, meaning the page still appeared as "Media application development" there.

This update fixes the issue.