### PR TITLE
[media] Enable features sections

### DIFF
--- a/media/rendering.html
+++ b/media/rendering.html
@@ -12,8 +12,8 @@
     <main>
       <section class="featureset well-deployed">
         <h2>Well-deployed technologies</h2>
-        <p>Few media-based services can usefully function without rendering audio or video content; the HTML5 specification provides widely deployed support for this essential feature. Video content can be rendered in any Web page via the <a data-feature="Video rendering" data-featureid="video"><code>&lt;video&gt;</code> element</a>.</p>
-        <div data-feature="Audio rendering">
+        <div data-feature="Audio/Video rendering">
+          <p>Few media-based services can usefully function without rendering audio or video content; the HTML5 specification provides widely deployed support for this essential feature. Video content can be rendered in any Web page via the <a data-featureid="video"><code>&lt;video&gt;</code> element</a>.</p>
           <p>Likewise, audio content can be rendered in any Web page via the <a data-featureid="audio"><code>&lt;audio&gt;</code> element</a>.</p>
           <p>Beyond the declarative approach enabled by the <code>&lt;audio&gt;</code> element, the <a data-featureid="webaudio">Web Audio API</a> provides a full-fledged audio processing API, which includes support for low-latency playback of audio content.</p>
         </div>

--- a/media/toc.json
+++ b/media/toc.json
@@ -5,6 +5,7 @@
     "url": "https://discourse.wicg.io/c/mediartc"
   },
   "github": "https://github.com/w3c/web-roadmaps",
+  "createFeatureSections": true,
   "pages": [
     {
       "url": "rendering.html",


### PR DESCRIPTION
Sets the new `createFeatureSections` flag to have the framework generate feature sections to visually group paragraphs that talk about a same overall feature under a section heading. See:
https://github.com/w3c/web-roadmaps#creating-feature-sections

Except for the first paragraph in the "Rendering" page, all pages that compose the roadmap already had `data-feature` attributes in `<div>` or `<p>` elements, so no need to update the actual contents to take advantage of the flag.

@chrisn, see rationale in https://github.com/w3c/web-roadmaps/pull/450 and https://w3c.github.io/web-roadmaps/mobile/graphics.html for a live example. I believe it makes pages more readable, but that's certainly open for debate. What about it?