### PR TITLE
[Media] Update pointer to requestVideoFrameCallback() proposal

### DIFF
--- a/data/video-rvfc.json
+++ b/data/video-rvfc.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://wicg.github.io/video-rvfc/",
+  "title": "HTMLVideoElement.requestVideoFrameCallback()",
+  "impl": {
+    "chromestatus": 6335927192387584
+  }
+}

--- a/media/processing.html
+++ b/media/processing.html
@@ -35,7 +35,7 @@
             <li><a data-featureid="webgpu">WebGPU</a> allows Web applications to perform operations such as rendering and computation on a Graphics Processing Unit (GPU).</li>
             <li>The <a data-featureid="webnn">Web Neural Network API</a> describes a dedicated low-level API for neural network inference hardware acceleration.</li>
             <li>The <a data-featureid="shape-detection">Shape Detection API</a> provides access to accelerated shape detectors (e.g. to recognize human faces and postures, or objects) on devices that embed relevant hardware such as most modern smartphones and laptops.</li>
-            <li>An <a href="https://discourse.wicg.io/t/proposal-video-requestanimationframe/3691">early proposal to create a <code>video.requestAnimationFrame</code> method</a> to signal when a video frame has been presented for composition and provide metadata about that frame.</li>
+            <li><a data-featureid="video-rvfc">HTMLVideoElement.requestVideoFrameCallback()</a> proposes a mechanism to signal when a video frame has been presented for composition and to provide metadata about that frame. This would allow drawing video frames onto a canvas at the video rate (instead of the browser's animation rate).</li>
             <li>An <a href="https://discourse.wicg.io/t/proposal-offscreenvideo/3952">early proposal to create an <code>OffscreenVideo</code> interface</a> inspired by <code>OffscreenCanvas</code> to allow processing of video in a worker.</li>
           </ul>
         </div>


### PR DESCRIPTION
The proposal is now being incubated in the WICG. Also note the change of name (it used to be "video.requestAnimationFrame").

@chrisn, for info.