### PR TITLE
Add more ids for the Chinese translation

### DIFF
--- a/mobile/adaptation.zh.html
+++ b/mobile/adaptation.zh.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
         <div data-feature="基于 CSS 的适配">
           <p><a data-featureid="mediaqueries">CSS 媒体查询</a>定义了一种机制，允许根据设备的一些特性（尤其是屏幕分辨率）调整网页的布局和行为。</p>
           <p><a data-featureid="viewport-units">与视口（viewport）相关的CSS单位 <code>vw</code>、<code>vh</code>、<code>vmin</code> 和 <code>vmax</code></a> 表示当前视口尺寸的百分比，并允许开发者设计自动适应视口尺寸变化的布局。</p>
@@ -24,7 +24,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="基于 CSS 的适配">
           <p><a data-featureid="css-device-adapt">CSS设备适配</a>定义了一组CSS指令来定义该布局应该基于的尺寸，相对于底层设备的大小——指定<code>&lt;meta name="viewport"&gt;</code>元素实现的内容。</p>
           <p><a data-featureid="css-size-adjust">CSS 移动文本大小调整</a>让文本适应页面的缩放部分。</p>
@@ -53,7 +53,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
         <div data-feature="基于 JS 的适配">
           <p>大多数移动设备都具有屏幕键盘，也通常让用户能够缩放页面。这两个功能都保留了<em>布局视口</em>（网页在布局其用户界面使用的视口），以免被 <code>position: fixed</code> 的元素弄乱屏幕。<a data-featureid="viewportapi">Visual Viewport API</a> 为开发人员提供了一种查看<em>可视视口</em>属性（用户当前可见的内容）并与之交互的方法，并在这些属性发生变化时得到通知。</p>
         </div>

--- a/mobile/forms.zh.html
+++ b/mobile/forms.zh.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
         <div data-feature="定制文本条目">
           <p>可以通过使用 <code><a data-featureid="inputtext">&lt;input type="<strong>email</strong>"&gt;</a></code>、<code><a href="https://html.spec.whatwg.org/multipage/input.html#telephone-state-(type=tel)">&lt;input type="<strong>tel</strong>"&gt;</a></code> 和 <code><a href="https://html.spec.whatwg.org/multipage/input.html#url-state-(type=url)">&lt;input type="<strong>url</strong>"&gt;</a></code> 优化那些通常并不容易的用户数据键入方法，例如专用的虚拟键盘，或访问设备记录的如地址簿或书签等数据。</p>
 
@@ -26,14 +26,14 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="剪贴板">
           <p>复制和粘贴操作是将文本从一个应用传递到另一个应用的一个核心机制，尤其是在文本输入仍然是挑战的设备上。<a data-featureid="clipboard-apis">剪贴板API和事件</a>规范描述了用于覆盖默认剪贴板操作（如添加元数据或修改内容格式）以及用于直接访问剪贴板内容（如使剪贴板数据在远程设备和本地应用之间保持同步）的API。</p>
         </div>
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>输入模式</dt>
           <dd><code><a data-featureid="inputmode">inputmode</a></code> 属性定义了文本输入所预期的文本输入类型。移动浏览器可以使用这些提示来渲染正确的屏幕键盘类型，例如当用户希望输入信用卡号码是展示一个数字键盘。这个属性已经不再被当前的大多数浏览器版本所支持，且这个属性已经被移出HTML规范。开发者应使用<code>tel</code>、<code>email</code> 和 <code>url</code>等更为具体的输入类型。</dd>

--- a/mobile/graphics.zh.html
+++ b/mobile/graphics.zh.html
@@ -12,7 +12,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="图形效果">
           <p>CSS 3及更高版本定义了定义了简单而强大的特性来创建图形效果，例如<a data-featureid="css-border-radius">圆角</a>、<a data-featureid="css-box-shadow">阴影效果</a>和<a data-featureid="css-2d">旋转内容</a>等。</p>
@@ -40,7 +40,7 @@
         <p>图形密集型应用（例如游戏）中的另一个重要的特性是使用整个屏幕来显示图形；在<a data-featureid="fullscreen">全屏API</a>上的工作可以请求和检测全屏显示，现在在 <a href="https://whatwg.org/">Web 超文本应用技术工作小组</a>中完成。</p>
       </section>
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="动画">
           <p>动画也可以通过脚本通过<a data-featureid="web-animations">Web动画</a>中的API进行管理。</p>
         </div>
@@ -57,7 +57,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
         <div data-feature="动画">
           <p>网页内容很少能够完整显示在移动设备的首屏，所以需要用户向下滚动。Web应用可能希望根据当前滚动位置调整其用户界面，比如在用户滚动时缩小顶部导航菜单或显示进度条。这项功能需要现在编写脚本，而<a data-featureid="scroll-animations">滚动关联动画</a>规范提出了一种基于CSS属性的声明性机制。</p>
         </div>

--- a/mobile/lifecycle.zh.html
+++ b/mobile/lifecycle.zh.html
@@ -14,7 +14,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="可见性检测">
           <p><a data-featureid="page-visibility">页面可见性</a>规范允许开发者检测他们的应用何时在前台，从而相应地调整他们的操作和资源消耗。</p>
@@ -22,7 +22,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="打包">
           <p>无论是否打包，用户都依靠各种元数据（名称、图标）在常用应用列表中来识别他们想要使用的应用。<a data-featureid="appmanifest">Web应用清单</a>规范允许开发人员将所有这些元数据放在一个 JSON 文件中。</p>
           <p>除了<a href="https://www.w3.org/TR/notifications/">Web通知</a>以外，<a data-featureid="badging">标记 API</a>定义了另一种通知机制，允许已经安装在设备上的 Web 应用（例如通过清单文件）设置一个标记，通常显示在主屏幕上应用程序的图标旁边，在应用程序的状态发生变化时通知用户可能需要注意的信息（如新消息）。</p>
@@ -48,7 +48,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <div data-feature="打包">
           <p><a data-featureid="packaging">Web 打包</a>文档描述了用于网站和应用的新包格式的用例，并概述了这种格式。</p>
@@ -70,7 +70,7 @@
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
 
         <dl>
           <dt>应用缓存</dt>

--- a/mobile/media.zh.html
+++ b/mobile/media.zh.html
@@ -12,7 +12,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
         <div data-feature="音频/视频播放">
           <p>HTML5 新增的 <code><strong><a data-featureid="video">&lt;video&gt;</a></strong></code> 和 <code><strong><a data-featureid="audio">&lt;audio&gt;</a></strong></code> 标签极大地改善了 Web 对多媒体内容的集成能力。它们允许将音频和视频内容无插件的嵌入到 Web 上，并允许开发者与音视频内容进行更加自由地交互。这些标签使得音频和视频内容成为 Web 上的一等公民，就像 Web 上已经存在了二十多年的图片一样。</p>
         </div>
@@ -26,7 +26,7 @@
         <p data-feature="图像和视频的分析和修改"><a data-featureid="html/2dcontext">画布2D上下文</a> API 允许修改图像，这也为<strong>编辑视频</strong>开启了可能，并为 Web 平台带来了多媒体处理的能力。</p>
       </section>
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <p data-feature="音频播放">在 <code>&lt;audio&gt;</code> 元素启用的声明性方法之外，<a data-featureid="webaudio">Web 音频 API</a> 提供了一个成熟的音频处理API，包括对音频内容低延迟播放的支持。</p>
 
@@ -69,7 +69,7 @@
         </div>
       </section>
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <div data-feature="分布式渲染">
           <p>多设备时计社区组目前正在探索多设备媒体渲染的另一方面：<a data-featureid="timing">时计对象</a>规范允许在跨设备并独立于网络拓扑的同时，保持视频、音频和其他数据流的同步性。这项努力需要更多有关方面的支持来取得进展。</p>
@@ -90,7 +90,7 @@
         </div>
       </section>
       <section>
-        <h2>目前尚未覆盖的工作</h2>
+        <h2 id="features-not-covered-by-ongoing-work">目前尚未覆盖的工作</h2>
         <dl>
           <dt>色彩管理</dt>
           <dd>为了确保正确呈现高动态范围（HDR）和宽色域的视频，内容提供商需要确定底层设备和浏览器是否有适当的支持。类似地，内容提供者需要一种机制来匹配颜色以混合 HDR 内容和标准动态范围（SDR）内容。<a href="https://www.w3.org/community/colorweb/">Web色彩社区组</a>聚集了来自不同行业的色彩专家，以改善 Web 上的色彩管理的状态。</dd>
@@ -102,7 +102,7 @@
         </dl>
       </section>
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>网络服务发现</dt>
           <dd><a data-featureid="discovery">网络服务发现API</a>通过提供与本地基于网络的媒体渲染器的集成，如 DLN 及 UPnP 等，为建立多设备操作提供较底层的方法。出于对隐私保护的顾虑及缺乏实现，这项工作没有继续下去。目前的解决方案是用户用代理来处理底层的网络发现，就像在<a data-featureid="secondscreen">呈现 API</a> 和<a data-featureid="remote-playback">远程回放 API</a> 中处理的那样。</dd>

--- a/mobile/network.zh.html
+++ b/mobile/network.zh.html
@@ -12,7 +12,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="HTTP 网络 API">
           <p><a data-featureid="xhr">XMLHttpRequest</a>（Ajax开发的基础）是一个广泛部署的API，用于使用 HTTP 和 HTTPs 协议从Web服务器加载内容：W3C 规范（以前称为XMLHttpRequest Level 2）旨在记录现有的已部署的 API（能够在不同域中的服务器上提出请求，对网络操作进度进行程序化反馈，以及更有效地处理二进制内容），这项工作现在已经在<a href="https://whatwg.org/">WHATWG</a>中完成了。WHATWG 的 <a data-featureid="fetch">Fetch API</a>还提供了一个更强大的基于 Promise 的替代方案。</p>
@@ -40,7 +40,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="底层I/O">
           <p><a data-featureid="streams">Streams</a>规范提供了用于高效地创建和接收数据流的API。移动网络的网络状况可能会出现波动，带宽可能受到限制；对低级别I/O原语的访问使 Web 应用内的流量控制能够将网络传输调整为某个读取器（如媒体播放器）的速度，还能改进感知性能，例如在 Service Worker 从先前缓存的内容中组装流并且在线获取内容以加速第一组页面的渲染操作时。在任何时候取消流以停止下载的能力也有助于在需要时立即为其他任务回收网络带宽。</p>
         </div>
@@ -57,7 +57,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
         <div data-feature="后台执行">
           <p><a data-featureid="background-sync">Web 后台同步</a>规范建立在 Service Workers 之上，通过在后台运行网络操作，使 Web 应用能够无缝地保持用户数据的最新状态，从而适应用户在移动设备上可能经常遇到的不可靠的连接。</p>
 

--- a/mobile/payment.zh.html
+++ b/mobile/payment.zh.html
@@ -13,13 +13,13 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <p data-feature="自动完成">HTML通过 <code>cc-<em>xxx</em></code> 提供了<a data-featureid="autocomplete">针对信用卡细节信息的自动完成</a>的具体支持，这些信息输入之后，使用信用卡就变得方便多了。</p>
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <div data-feature="Web 支付">
           <p>在2014年一场非常成功的 <a href="https://www.w3.org/2013/10/payments/">Web 支付研讨会</a>以及 Web 支付兴趣组开展的<a href="https://www.w3.org/TR/web-payments-use-cases/">关于 Web 支付用例和优先级</a>的讨论之后，W3C启动了 <a href="https://www.w3.org/Payments/IG/">Web 支付工作组</a>来开发辅助Web应用支付操作的浏览器API：</p>

--- a/mobile/performance.zh.html
+++ b/mobile/performance.zh.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="计时 API">
           <p><a href="https://www.w3.org/webperf/">Web 性能工作组</a>开发了一些规范，它们向 Web 应用提供计时 API，用于分析各任务耗费的时间。</p>
@@ -63,7 +63,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
         <div data-feature="网络优先级">
           <p><a data-featureid="resource-hints">资源提示</a>和<a data-featureid="preload">预加载</a>规范使开发人员能够通过延迟下载或执行下载的资源来优化资源的下载。</p>
         </div>
@@ -105,7 +105,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <div data-feature="计时 API">
           <p><a data-featureid="frame-timing">帧计时 API</a> 旨在提供应用在用户设备上运行时获得的每秒帧数的详细信息。</p>

--- a/mobile/security.zh.html
+++ b/mobile/security.zh.html
@@ -16,7 +16,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="安全加强">
           <p>用户的第一道防线以及 Web 应用的隔离单元是同源策略，它大致限制了 Web 应用可以访问同一来源的内容和数据，这里的来源是指协议、域名和端口的组合。</p>
@@ -41,7 +41,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <div data-feature="安全加强">
           <p>跨站脚本（XSS）是Web上的主要攻击方式之一。<a data-featureid="trusted-types">可信任类型</a>允许应用锁定基于 DOM 的 XSS 注入接收器（例如，<code>Element.innerHTML</code> 或 <code>Location.href</code> 设置器），以仅接受不可欺骗的、含有类型的值来代替字符串。</p>
@@ -69,14 +69,14 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
         <div data-feature="权限">
             <p>不同的API使用不同的机制来授予使用或访问潜在强大功能的权限。为了简化与权限相关的代码的设计，<a data-featureid="permissions-request">请求权限</a>和<a data-featureid="permissions-revoke">放弃权限</a>两个标准提议扩展<a href="https://www.w3.org/TR/permissions/">权限API</a>，以提供一个统一的方法请求和撤销权限。</p>
         </div>
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>HTTP请求过滤</dt>
           <dd><a data-featureid="epr">入口监管</a>规范提供了另一个加强安全的层面。它定义了一种机制来过滤可以从外部站点发起的 HTTP 请求的类型，降低了跨站点脚本和跨站点请求伪造的风险。这个规范的工作暂时停止了。</dd>

--- a/mobile/sensors.zh.html
+++ b/mobile/sensors.zh.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
 
         <div data-feature="地理位置">
           <p><a data-featureid="geolocation">地理位置应用编程接口</a>提供了一个独立于底层技术（GPS、Wi-Fi网络识别、蜂窝网络中的三角测量等）的用于定位设备的通用接口。</p>
@@ -23,7 +23,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <div data-feature="通用传感器">
           <p><a data-featureid="generic-sensor">通用传感器API</a>定义了一个以一致的方式将传感器数据开放给Web平台的框架。该规范特别定义了编写具体传感器规格的蓝图以及可扩展以适应不同传感器类型的一个抽象的 <code>Sensor</code> 接口。许多传感器API构建在通用传感器API之上。</p>
@@ -57,7 +57,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <p data-feature="近场通讯"><a href="http://w3c.github.io/web-nfc/" data-featureid="webnfc">Web 近场通讯（NFC）API</a>已经开始在<a href="https://www.w3.org/community/web-nfc/">Web NFC社区组</a>中开始开发，能够在两个紧邻的设备之间进行无线通信。</p>
 
@@ -65,7 +65,7 @@
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>地理围栏 API</dt>
           <dd>检测设备何时进入给定地理区域的能力将能够基于用户在特定地点的实际存在来实现交互和通知。为此，地理位置工作组开发了<a data-featureid="geofencing">地理围栏 API</a>。这项工作已经停止，部分原因在于未能找到一种很好的方法来解决有关隐私的权限问题，还因为该 API 依赖于当时还不稳定的 <a href="https://w3c.github.io/ServiceWorker/">Service Workers</a>。该规范的工作可能会在未来继续，这取决于潜在的实现者的兴趣。</dd>

--- a/mobile/storage.zh.html
+++ b/mobile/storage.zh.html
@@ -11,7 +11,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
         <p data-feature="简单数据存储">对于简单的数据存储，<a data-featureid="webstorage">Web存储</a>规范提供了两个基本机制，<code>localStorage</code> 和 <code>sessionStorage</code>，前者可以无限期地保存数据，后者基于浏览器会话。</p>
 
         <p data-feature="数据库查询/更新">在基于文件的访问之上，<a data-featureid="indexeddb">索引数据库 API</a>（IndexedDB）定义了一个与 JavaScript 集成的值和分层对象的数据库，并且可以非常有效地进行查询和更新 - <a href="https://w3c.github.io/IndexedDB/">3.0版</a>正在开发中。</p>
@@ -21,7 +21,7 @@
         <p data-feature="文件下载"><a data-featureid="html5-download">HTML5 的 <code>download</code> 属性</a>提供了一个简单的机制来触发文件下载（而不是页面导航），并可以设置用户友好的文件名。</p>
       </section>
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <div data-feature="文件操作">
           <p>尽管移动设备通常没有明显的文件系统，但通常至少存在某种文件系统的概念。<a data-featureid="fileapi">文件API</a>提供了一个用于表示Web应用中的文件对象的API，还可用以可编程方式选择文件并访问文件中的数据。该API目前是只读的，关于读写API的讨论现已恢复，请参阅下面的<a href="#native-file-system">本地文件系统</a>标准。</p>
@@ -29,7 +29,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <p data-feature="存储配额">随着越来越多的数据需要被浏览器存储（例如用于离线使用），对于开发者来说获得可靠的存储空间变得至关重要。<a data-featureid="storage">存储</a>规范将允许 Web 应用程序获取配额估计的存储空间，并要求将其存储的数据视为持久性数据。在未经用户明确同意的情况下，这些数据不能被抢占。</p>
 
@@ -47,7 +47,7 @@
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>配额管理 API</dt>
           <dd>研发<a data-featureid="quota">配额管理 API</a> 的初衷是 Web 平台工作组希望提供一个管理本地存储资源使用和可用性的API，由于新的<a data-featureid="storage">存储</a>提议的出现现在已不再继续研发。

--- a/mobile/userinput.zh.html
+++ b/mobile/userinput.zh.html
@@ -12,7 +12,7 @@
     </header>
     <main>
       <section class="featureset well-deployed">
-        <h2>广泛部署的技术</h2>
+        <h2 id="well-deployed-technologies">广泛部署的技术</h2>
         <div data-feature="基于触控的交互">
           <p>越来越多的移动设备依赖于触控。尽管在Web平台中公认的传统交互方式（键盘、鼠标输入）仍然可以在这种情况下应用，但更具针对性地处理触控输入是创建适应性良好的用户体验的关键因素，<a data-featureid="touchevent">文档对象模型中的触摸事件</a>可以解决这个问题。</p>
           <p><a data-featureid="pointer-events">指针事件</a>规范定义了一个鼠标、触摸和笔事件的统一模型。它为触摸事件提供了一种互补且更加统一的方法。指针事件包括允许过滤元素上的手势事件的 CSS 属性 <a data-featureid="css-touch-action"><code>touch-action</code></a>，并在浏览器中广泛实现。</p>
@@ -32,7 +32,7 @@
       </section>
 
       <section class="featureset in-progress">
-        <h2>开发中的技术</h2>
+        <h2 id="technologies-in-progress">开发中的技术</h2>
 
         <div data-feature="游戏控制器">
           <p><a data-featureid="gamepad">游戏手柄</a>规范定义了一个与连接到设备的游戏手柄（例如通过蓝牙与智能手机配对的游戏手柄设备）交互的底层接口。</p>
@@ -53,7 +53,7 @@
       </section>
 
       <section class="featureset exploratory-work">
-        <h2>探索性工作</h2>
+        <h2 id="exploratory-work">探索性工作</h2>
 
         <p data-feature="基于语音的交互">移动设备，特别是手机，在很多情况下也非常适合语音交互；<a href="https://www.w3.org/community/speech-api/">语音 API 社区组</a>开发了一个JavaScript API 来支持通过口头命令与网页进行交互。<a data-featureid="speech-api/synthesis">语音合成</a>在浏览器中有很好的支持。对<a data-featureid="speech-api/recognition">语音识别</a>的支持仍在进行中。</p>
 
@@ -78,7 +78,7 @@
       </section>
 
       <section>
-          <h2>目前尚未覆盖的工作</h2>
+          <h2 id="features-not-covered-by-ongoing-work">目前尚未覆盖的工作</h2>
           <dl>
             <dt>手势事件</dt>
             <dd>如上所述，基于触摸的交互在移动设备上很常见，并且可通过<a data-featureid="touchevent">触摸事件</a>提供给 Web 应用。<strong>基于手势的交互</strong>（包括捏合、旋转和滑动等）也是移动设备上的常见交互范例。Web开发者可在某种程度上从触摸事件中获取手势事件，但可能需要为不同的浏览器开发多个版本。对这些交互的原生支持将降低碎片化程度并提高性能。早期关于定义<a href="https://github.com/JuntaoPeng/GestureEvents/blob/master/GestureEvents.md#gesture-events">手势事件</a>的讨论已经在<a href="https://www.w3.org/community/mwma/">合并 Web 和移动应用社区组</a>中开始了讨论。</dd>
@@ -86,7 +86,7 @@
       </section>
 
       <section>
-        <h2>不再进行的工作</h2>
+        <h2 id="discontinued-features">不再进行的工作</h2>
         <dl>
           <dt>基于意图的事件</dt>
           <dd>随着 Web 来到新的设备上，并且随着设备获得新的用户交互机制，允许 Web 开发者对更抽象的用户交互集合作出响应似乎是有用的：Web 应用无需再对“点击”、“按键”或“触摸事件“进行响应，而转为对“撤消“或“下一页”的作出响应（无论用户如何给设备发出这些指令）。<a data-featureid="indie-ui-events">IndieUI Events</a> 规范就是为了解决这个需求。由于缺乏实现，目前这项工作已经停止。</dd>


### PR DESCRIPTION
It would be better if these ids can be automatically generated, but before that happens, I would like to add these more semantic ids (comparing with the ones generated by [generate-utils.js](https://github.com/w3c/web-roadmaps/blob/670fa5758a1d5803e6bf54bf54bd346f68f29600/js/generate-utils.js#L55)) to the Chinese translation.