### PR TITLE
Lookup spec in browser-specs, first pass at cleaning data

### DIFF
--- a/data/accelerometer.json
+++ b/data/accelerometer.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/accelerometer/",
     "impl": {
         "caniuse": "accelerometer",
         "chromestatus": 5698781827825664

--- a/data/ambient-light.json
+++ b/data/ambient-light.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/ambient-light/",
   "impl": {
     "caniuse": "ambient-light",
     "edgestatus": "Ambient Light Sensor API",

--- a/data/annotation-model.json
+++ b/data/annotation-model.json
@@ -1,10 +1,3 @@
 {
-    "url": "https://www.w3.org/TR/annotation-model/",
-    "wgs": [
-        {
-          "label": "Web Annotation Working Group",
-          "url": "https://www.w3.org/annotation/"
-        }
-    ],
     "impl" : {}
 }

--- a/data/appmanifest.json
+++ b/data/appmanifest.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/appmanifest/",
   "impl": {
     "caniuse": "web-app-manifest",
     "chromestatus": 6488656873259008,

--- a/data/atag20.json
+++ b/data/atag20.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/ATAG20/"
 }

--- a/data/audio-output.json
+++ b/data/audio-output.json
@@ -5,7 +5,6 @@
     "edgestatus": "Audio Output Devices API",
     "webkitstatus": null
   },
-  "url": "https://www.w3.org/TR/audio-output/",
   "features": {
     "sinkId": {
       "title": "ID of the audio device",

--- a/data/audiobooks.json
+++ b/data/audiobooks.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/audiobooks/"
 }

--- a/data/background-fetch.json
+++ b/data/background-fetch.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/background-fetch/",
-  "title": "Background Fetch",
   "impl": {
     "chromestatus": 5712608971718656
   }

--- a/data/background-sync.json
+++ b/data/background-sync.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/background-sync/spec/",
   "impl": {
     "caniuse": "background-sync",
     "chromestatus": 6170807885627392,

--- a/data/badging.json
+++ b/data/badging.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://w3c.github.io/badging/",
-  "title": "Badging API",
   "wgs": [
     {
       "label": "Web Applications Working Group",

--- a/data/beacon.json
+++ b/data/beacon.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/beacon/",
   "impl": {
     "caniuse": "beacon",
     "chromestatus": 5517433905348608,

--- a/data/clipboard-apis.json
+++ b/data/clipboard-apis.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/clipboard-apis/",
   "impl": {
     "chromestatus": 5861289330999296
   }

--- a/data/construct-stylesheets.json
+++ b/data/construct-stylesheets.json
@@ -1,6 +1,4 @@
 {
-    "url": "https://wicg.github.io/construct-stylesheets/",
-    "title": "Constructable Stylesheet Objects",
     "impl": {
       "chromestatus": 5394843094220800
     }

--- a/data/cookie-store.json
+++ b/data/cookie-store.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/cookie-store/",
   "impl": {
     "chromestatus": 5658847691669504
   }

--- a/data/csp3.json
+++ b/data/csp3.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/CSP3/",
   "impl": {
     "webkitstatus": "specification-content-security-policy-level-3"
   },

--- a/data/css-animations.json
+++ b/data/css-animations.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-animations-1/",
   "impl": {
     "caniuse": "css-animation",
     "chromestatus": 6121990213599232

--- a/data/css-break-3.json
+++ b/data/css-break-3.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-break-3/",
   "features": {
     "box-decoration-break": {
       "title": "box-decoration-break property",

--- a/data/css-content-3.json
+++ b/data/css-content-3.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-content-3/",
   "impl": {
     "mdn": "css.properties.content"
   }

--- a/data/css-device-adapt.json
+++ b/data/css-device-adapt.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-device-adapt-1/",
   "impl": {
     "caniuse": "css-deviceadaptation",
     "chromestatus": 4737164243894272,

--- a/data/css-flexbox.json
+++ b/data/css-flexbox.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-flexbox-1/",
   "impl": {
     "caniuse": "flexbox",
     "chromestatus": 4837301406400512,

--- a/data/css-font-loading.json
+++ b/data/css-font-loading.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-font-loading-3/",
   "impl": {
     "caniuse": "font-loading",
     "chromestatus": 6244676289953792,

--- a/data/css-fonts-4.json
+++ b/data/css-fonts-4.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-fonts-4/",
   "features": {
     "variable": {
       "title": "Variable fonts",

--- a/data/css-gcpm-3.json
+++ b/data/css-gcpm-3.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-gcpm-3/",
   "impl": {
     "chromestatus": 5400251359821824,
     "edgestatus": "Generated Content for Paged Media"

--- a/data/css-grid-1.json
+++ b/data/css-grid-1.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-grid-1/",
   "impl": {
     "caniuse": "css-grid",
     "chromestatus": 4589636412243968,

--- a/data/css-line-grid-1.json
+++ b/data/css-line-grid-1.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/css-line-grid-1/"
 }

--- a/data/css-overscroll.json
+++ b/data/css-overscroll.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-overscroll-1/",
   "impl": {
     "caniuse": "css-overscroll-behavior",
     "chromestatus": 5734614437986304,

--- a/data/css-page-3.json
+++ b/data/css-page-3.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-page-3/",
   "impl": {
     "caniuse": "css-paged-media"
   }

--- a/data/css-page-floats-3.json
+++ b/data/css-page-floats-3.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/css-page-floats-3/"
 }

--- a/data/css-paint-api.json
+++ b/data/css-paint-api.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/css-paint-api-1/",
     "impl": {
       "caniuse": "css-paint-api",
       "chromestatus": 5685444318593024,

--- a/data/css-rhythm-1.json
+++ b/data/css-rhythm-1.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-rhythm-1/",
   "impl": {
     "webkitstatus": "specification-css-rhythmic-sizing"
   },

--- a/data/css-ruby.json
+++ b/data/css-ruby.json
@@ -1,8 +1,7 @@
 {
-  "url": "https://www.w3.org/TR/css-ruby-1/",
   "features": {
     "ruby-align": {
-      "url": "https://www.w3.org/TR/css-ruby-1/#ruby-align-property",
+      "url": "#ruby-align-property",
       "title": "The ruby-align property",
       "impl": {
         "mdn": "css.properties.ruby-align"
@@ -10,7 +9,7 @@
     },
 
     "ruby-position": {
-      "url": "https://www.w3.org/TR/css-ruby-1/#rubypos",
+      "url": "#rubypos",
       "title": "The ruby-position property",
       "impl": {
         "mdn": "css.properties.ruby-position"

--- a/data/css-scoping.json
+++ b/data/css-scoping.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-scoping-1/",
   "features": {
     "host": {
       "url": "#selectordef-host",

--- a/data/css-scroll-snap.json
+++ b/data/css-scroll-snap.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-scroll-snap-1/",
   "impl": {
     "caniuse": "css-snappoints",
     "chromestatus": 5721832506261504,

--- a/data/css-shadow-parts.json
+++ b/data/css-shadow-parts.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-shadow-parts-1/",
   "impl": {
     "chromestatus": 5763933658939392,
     "webkitstatus": "specification-css-shadow-parts",

--- a/data/css-size-adjust.json
+++ b/data/css-size-adjust.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://drafts.csswg.org/css-size-adjust/",
-  "title": "CSS Mobile Text Size Adjustment Module Level 1",
   "wgs": [
     {
       "url": "https://www.w3.org/Style/CSS/members",

--- a/data/css-transitions.json
+++ b/data/css-transitions.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-transitions-1/",
   "impl": {
     "caniuse": "css-transitions"
   }

--- a/data/css-will-change.json
+++ b/data/css-will-change.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/css-will-change-1/",
   "impl": {
     "caniuse": "will-change",
     "chromestatus": 5954199330226176,

--- a/data/css2.json
+++ b/data/css2.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/CSS2/"
 }

--- a/data/cssom-view.json
+++ b/data/cssom-view.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/cssom-view-1/",
   "features": {
     "scroll-behavior": {
       "title": "scroll-behavior property",

--- a/data/device-memory.json
+++ b/data/device-memory.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://w3c.github.io/device-memory/",
-  "title": "Device Memory 1",
   "features": {
     "header": {
       "title": "Header field",

--- a/data/dom.json
+++ b/data/dom.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://dom.spec.whatwg.org/",
-  "title": "DOM",
   "features": {
     "shadow": {
       "url": "#shadow-trees",

--- a/data/element-timing.json
+++ b/data/element-timing.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/element-timing/",
-  "title": "Element Timing API",
   "features": {
     "img": {
       "title": "Support for images",

--- a/data/event-timing.json
+++ b/data/event-timing.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/event-timing/",
-  "title": "Event Timing API",
   "impl": {
     "chromestatus": 5167290693713920
   }

--- a/data/fetch.json
+++ b/data/fetch.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://fetch.spec.whatwg.org/",
-  "title": "Fetch",
   "impl": {
     "caniuse": "fetch",
     "chromestatus": 6730533392351232,

--- a/data/fileapi.json
+++ b/data/fileapi.json
@@ -1,6 +1,4 @@
 {
-  "url" : "https://www.w3.org/TR/FileAPI/",
-  "title" : "File API",
   "impl": {
     "caniuse": "fileapi"
   }

--- a/data/frame-timing.json
+++ b/data/frame-timing.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/frame-timing/",
   "impl": {
     "chromestatus": 5558926443544576,
     "edgestatus": "Frame Timing",

--- a/data/fullscreen.json
+++ b/data/fullscreen.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://fullscreen.spec.whatwg.org/",
-  "title": "Fullscreen API",
   "impl": {
     "caniuse": "fullscreen",
     "chromestatus": 5259513871466496,

--- a/data/gamepad.json
+++ b/data/gamepad.json
@@ -1,6 +1,4 @@
 {
-  "url" : "https://www.w3.org/TR/gamepad/",
-  "title" : "Gamepad",
   "impl": {
     "caniuse": "gamepad",
     "chromestatus": 5118776383111168,

--- a/data/generic-sensor.json
+++ b/data/generic-sensor.json
@@ -1,3 +1,2 @@
 {
-    "url": "https://www.w3.org/TR/generic-sensor/"
 }

--- a/data/geolocation-sensor.json
+++ b/data/geolocation-sensor.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/geolocation-sensor/",
   "polyfills": [
       {
         "label": "sensor-polyfills",

--- a/data/gyroscope.json
+++ b/data/gyroscope.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/gyroscope/",
   "impl": {
     "caniuse": "gyroscope",
     "chromestatus": 5698781827825664

--- a/data/html-media-capture.json
+++ b/data/html-media-capture.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/html-media-capture",
   "impl": {
     "caniuse": "html-media-capture"
   }

--- a/data/html.json
+++ b/data/html.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://html.spec.whatwg.org/multipage/",
-  "title": "HTML",
   "features": {
     "template": {
       "url": "https://html.spec.whatwg.org/multipage/scripting.html#the-template-element",

--- a/data/ime-api.json
+++ b/data/ime-api.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/ime-api/",
   "impl": {
     "caniuse": "ime",
     "chromestatus": 6366722080636928

--- a/data/indie-ui-events.json
+++ b/data/indie-ui-events.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/indie-ui-events/"
 }

--- a/data/is-input-pending.json
+++ b/data/is-input-pending.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/is-input-pending/",
-  "title": "Early detection of input events",
   "impl": {
     "chromestatus": 5719830432841728
   }

--- a/data/js-self-profiling.json
+++ b/data/js-self-profiling.json
@@ -1,4 +1,2 @@
 {
-  "url": "https://wicg.github.io/js-self-profiling/",
-  "title": "JS Self-Profiling API"
 }

--- a/data/layout-instability.json
+++ b/data/layout-instability.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/layout-instability/",
-  "title": "Layout Instability API",
   "impl" : {
     "chromestatus": 5110682739539968
   }

--- a/data/longtasks.json
+++ b/data/longtasks.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/longtasks-1/",
   "impl": {
     "chromestatus": 5738471184400384,
     "mdn": "api.PerformanceLongTaskTiming"

--- a/data/magnetometer.json
+++ b/data/magnetometer.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/magnetometer/",
   "impl": {
     "caniuse": "magnetometer",
     "chromestatus": 5698781827825664

--- a/data/me-media-timed-events.json
+++ b/data/me-media-timed-events.json
@@ -1,5 +1,5 @@
 {
-  "url": "https://w3c.github.io/me-media-timed-events/",
+  "url": "https://www.w3.org/TR/media-timed-events/",
   "title": "Media Timed Events",
   "wgs": [
     {

--- a/data/media-capabilities.json
+++ b/data/media-capabilities.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/media-capabilities/",
   "features": {
     "encoding": {
       "title": "Encoding capabilities",

--- a/data/media-playback-quality.json
+++ b/data/media-playback-quality.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://w3c.github.io/media-playback-quality/",
   "wgs": [
     {
       "label": "Media Working Group",

--- a/data/mediasession.json
+++ b/data/mediasession.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/mediasession/",
   "impl": {
     "caniuse": null,
     "chromestatus": 5639924124483584,

--- a/data/mst-content-hint.json
+++ b/data/mst-content-hint.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/mst-content-hint/",
     "impl": {
         "chromestatus": 5689466211532800
     }

--- a/data/native-file-system.json
+++ b/data/native-file-system.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/native-file-system/",
-  "title": "Native File System",
   "impl": {
     "chromestatus": 6284708426022912
   }

--- a/data/navigation-timing.json
+++ b/data/navigation-timing.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/navigation-timing/",
   "impl": {
     "caniuse": "nav-timing",
     "chromestatus": 5584144679567360,

--- a/data/netinfo.json
+++ b/data/netinfo.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/netinfo/",
   "impl": {
     "caniuse": "netinfo",
     "chromestatus": 6338383617982464

--- a/data/notifications.json
+++ b/data/notifications.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://notifications.spec.whatwg.org/",
-  "title": "Notifications API",
   "impl": {
     "caniuse": "notifications",
     "chromestatus": 5064350557536256,

--- a/data/page-lifecycle.json
+++ b/data/page-lifecycle.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/page-lifecycle/",
   "impl": {
     "chromestatus": 5644602711212032
   }

--- a/data/page-visibility.json
+++ b/data/page-visibility.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/page-visibility/",
   "impl": {
     "caniuse": "pagevisibility",
     "chromestatus": 5689697795833856,

--- a/data/paint-timing.json
+++ b/data/paint-timing.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/paint-timing/",
   "impl": {
     "chromestatus": 5688621814251520,
     "mdn": "api.PerformancePaintTiming"

--- a/data/payment-handler.json
+++ b/data/payment-handler.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/payment-handler/",
   "impl": {
     "chromestatus": 5160285237149696,
     "mdn": "api.PaymentManager"

--- a/data/payment-method-basic-card.json
+++ b/data/payment-method-basic-card.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/payment-method-basic-card/",
   "impl": {
     "chromestatus": 5408502604365824,
     "mdn": "api.BasicCardRequest"

--- a/data/payment-method-id.json
+++ b/data/payment-method-id.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/payment-method-id/"
 }

--- a/data/payment-method-manifest.json
+++ b/data/payment-method-manifest.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/payment-method-manifest/",
   "impl": {
     "chromestatus": 5716168929181696
   }

--- a/data/payment-request.json
+++ b/data/payment-request.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/payment-request/",
   "impl": {
     "caniuse": "payment-request",
     "chromestatus": 5639348045217792,

--- a/data/performance-timeline.json
+++ b/data/performance-timeline.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/performance-timeline/",
   "features": {
     "observer": {
       "title": "PerformanceObserver interface",

--- a/data/permissions-policy.json
+++ b/data/permissions-policy.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/permissions-policy-1/",
   "impl": {
     "caniuse": "permissions-policy",
     "chromestatus": 5745992911552512

--- a/data/permissions-request.json
+++ b/data/permissions-request.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/permissions-request/",
-  "title": "Requesting Permissions",
   "impl": {
     "chromestatus": 5707368532803584
   }

--- a/data/permissions-revoke.json
+++ b/data/permissions-revoke.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/permissions-revoke/",
-  "title": "Relinquishing Permissions",
   "impl": {
     "chromestatus": 5707368532803584
   }

--- a/data/permissions.json
+++ b/data/permissions.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/permissions/",
   "impl": {
     "caniuse": "permissions-api",
     "chromestatus": 6376494003650560

--- a/data/picture-in-picture.json
+++ b/data/picture-in-picture.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/picture-in-picture/",
   "impl": {
     "caniuse": "picture-in-picture",
     "chromestatus": 5729206566649856,

--- a/data/pointerlock.json
+++ b/data/pointerlock.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/pointerlock",
   "impl": {
     "caniuse": "pointerlock",
     "chromestatus": 6753200417800192,

--- a/data/portals.json
+++ b/data/portals.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://github.com/WICG/portals/blob/master/explainer.md",
-  "title": "Portals",
   "impl": {
     "chromestatus": 4828882419056640
   }

--- a/data/preload.json
+++ b/data/preload.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/preload/",
   "impl": {
     "caniuse": "link-rel-preload",
     "chromestatus": 5757468554559488,

--- a/data/priority-hints.json
+++ b/data/priority-hints.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/priority-hints/",
-  "title": "Priority Hints",
   "impl": {
     "chromestatus": 5273474901737472
   }

--- a/data/proximity.json
+++ b/data/proximity.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/proximity/",
   "impl": {
     "caniuse": "proximity",
     "other": [

--- a/data/referrer-policy.json
+++ b/data/referrer-policy.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/referrer-policy/",
   "impl": {
     "caniuse": "referrer-policy",
     "chromestatus": 5639972996513792

--- a/data/remote-playback.json
+++ b/data/remote-playback.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/remote-playback/",
   "impl": {
     "chromestatus": 5778318691401728
   }

--- a/data/requestidlecallback.json
+++ b/data/requestidlecallback.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/requestidlecallback/",
   "impl": {
     "caniuse": "requestidlecallback",
     "chromestatus": 5572795866021888,

--- a/data/resize-observer.json
+++ b/data/resize-observer.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/resize-observer-1/",
     "impl": {
         "caniuse": "resizeobserver",
         "chromestatus": 5705346022637568

--- a/data/resource-hints.json
+++ b/data/resource-hints.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/resource-hints/",
   "features": {
     "dns-prefetch": {
       "title": "DNS prefetch",

--- a/data/resource-timing.json
+++ b/data/resource-timing.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/resource-timing-1/",
   "impl": {
     "caniuse": "resource-timing",
     "chromestatus": 5796350423728128,

--- a/data/screen-orientation.json
+++ b/data/screen-orientation.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/screen-orientation/",
   "impl": {
     "caniuse": "screen-orientation",
     "chromestatus": 6191285283061760,

--- a/data/scroll-animations.json
+++ b/data/scroll-animations.json
@@ -1,3 +1,2 @@
 {
-    "url": "https://wicg.github.io/scroll-animations/"
 }

--- a/data/selectors-states.json
+++ b/data/selectors-states.json
@@ -1,10 +1,4 @@
 {
     "url": "https://www.w3.org/TR/selectors-states/",
-    "wgs": [
-        {
-          "label": "Web Annotation Working Group",
-          "url": "https://www.w3.org/annotation/"
-        }
-    ],
     "impl" : {}
 }

--- a/data/server-timing.json
+++ b/data/server-timing.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/server-timing",
   "impl": {
     "chromestatus": 5695708376072192,
     "edgestatus": "Server Timing",

--- a/data/speech-api.json
+++ b/data/speech-api.json
@@ -1,12 +1,4 @@
 {
-  "url": "https://w3c.github.io/speech-api/",
-  "title": "Web Speech API",
-  "wgs": [
-    {
-      "url": "https://www.w3.org/community/speech-api/",
-      "label": "Speech API Community Group"
-    }
-  ],
   "features": {
     "recognition": {
       "title": "Speech recognition",

--- a/data/storage.json
+++ b/data/storage.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://storage.spec.whatwg.org/",
-  "title": "Storage",
   "impl": {
     "mdn": "api.StorageManager"
   },

--- a/data/streams.json
+++ b/data/streams.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://streams.spec.whatwg.org/",
-  "title": "Streams",
   "impl": {
     "caniuse": "streams",
     "chromestatus": 6605041225957376,

--- a/data/task-scheduler.json
+++ b/data/task-scheduler.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/task-scheduler/"
 }

--- a/data/timing-entrytypes-registry.json
+++ b/data/timing-entrytypes-registry.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/timing-entrytypes-registry/"
 }

--- a/data/vibration.json
+++ b/data/vibration.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/vibration/",
   "impl": {
     "caniuse": "vibration",
     "chromestatus": 5698768766763008,

--- a/data/video-rvfc.json
+++ b/data/video-rvfc.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/video-rvfc/",
-  "title": "HTMLVideoElement.requestVideoFrameCallback()",
   "impl": {
     "chromestatus": 6335927192387584
   }

--- a/data/wake-lock.json
+++ b/data/wake-lock.json
@@ -1,3 +1,2 @@
 {
-  "url": "https://www.w3.org/TR/wake-lock/"
 }

--- a/data/wasm-core.json
+++ b/data/wasm-core.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/wasm-core-1/",
   "impl": {
     "caniuse": "wasm",
     "chromestatus": 5453022515691520,

--- a/data/web-animations.json
+++ b/data/web-animations.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/web-animations-1/",
   "impl": {
     "caniuse": "web-animation",
     "chromestatus": 5650817352728576,

--- a/data/web-locks.json
+++ b/data/web-locks.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/web-locks/",
-  "title": "Web Locks API",
   "impl": {
     "chromestatus": 5712361335816192,
     "mdn": "api.Navigator.locks"

--- a/data/web-share-target.json
+++ b/data/web-share-target.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://w3c.github.io/web-share-target/",
-  "title": "Web Share Target API",
   "wgs": [
     {
       "label": "Web Applications Working Group",

--- a/data/web-share.json
+++ b/data/web-share.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/web-share/",
   "impl": {
     "caniuse": "web-share",
     "chromestatus": 5668769141620736,

--- a/data/web-transport.json
+++ b/data/web-transport.json
@@ -1,4 +1,2 @@
 {
-  "url": "https://wicg.github.io/web-transport/",
-  "title": "WebTransport"
 }

--- a/data/webaudio.json
+++ b/data/webaudio.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/webaudio/",
   "impl": {
     "caniuse": "audio-api",
     "chromestatus": 6261718720184320,

--- a/data/webauthn.json
+++ b/data/webauthn.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/webauthn-1/",
   "impl": {
     "caniuse": "webauthn",
     "chromestatus": 5669923372138496,

--- a/data/webgpu.json
+++ b/data/webgpu.json
@@ -1,6 +1,5 @@
 {
   "url": "https://gpuweb.github.io/gpuweb/",
-  "title": "WebGPU",
   "wgs": [
     {
       "url": "https://www.w3.org/2020/gpu/",

--- a/data/webhid.json
+++ b/data/webhid.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://wicg.github.io/webhid/",
-  "title": "WebHID API",
   "impl": {
     "chromestatus": 5172464636133376
   }

--- a/data/webrtc-stats.json
+++ b/data/webrtc-stats.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/webrtc-stats/",
     "impl": {
       "chromestatus": 5665052275245056
     }

--- a/data/webrtc-svc.json
+++ b/data/webrtc-svc.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/webrtc-svc/",
     "impl": {
       "chromestatus": 5769626174619648
     }

--- a/data/websockets.json
+++ b/data/websockets.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/websockets/",
   "impl": {
     "caniuse": "websockets",
     "chromestatus": 6555138000945152,

--- a/data/webusb.json
+++ b/data/webusb.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://wicg.github.io/webusb/",
   "impl": {
     "caniuse": "webusb",
     "chromestatus": 5651917954875392,

--- a/data/webvtt.json
+++ b/data/webvtt.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/webvtt1/",
   "impl": {
     "caniuse": "webvtt"
   }

--- a/data/webxr-ar-module.json
+++ b/data/webxr-ar-module.json
@@ -1,3 +1,2 @@
 {
-    "url": "https://www.w3.org/TR/webxr-ar-module/"
 }

--- a/data/webxr-gamepads-module.json
+++ b/data/webxr-gamepads-module.json
@@ -1,5 +1,4 @@
 {
-    "url": "https://www.w3.org/TR/webxr-gamepads-module/",
     "impl": {
       "chromestatus": 5659025263820800
     }

--- a/data/webxr.json
+++ b/data/webxr.json
@@ -1,5 +1,4 @@
 {
-  "url": "https://www.w3.org/TR/webxr/",
   "impl": {
     "caniuse": "webxr",
     "chromestatus": 5680169905815552,

--- a/data/xhr.json
+++ b/data/xhr.json
@@ -1,6 +1,4 @@
 {
-  "url": "https://xhr.spec.whatwg.org/",
-  "title": "XMLHttpRequest",
   "impl": {
     "caniuse": "xhr2"
   }

--- a/games/userinput.html
+++ b/games/userinput.html
@@ -58,7 +58,7 @@
         <div data-feature="Sensors">
           <p>The <a data-featureid="generic-sensor">Generic Sensor API</a> defines a framework for exposing sensor data to the Web platform in a consistent way. In particular, the specification defines a blueprint for writing specifications of concrete sensors along with an abstract <code>Sensor</code> interface that can be extended to accommodate different sensor types.</p>
 
-          <p>A number of sensor APIs are being built on top of the Generic Sensor API. The <a data-featureid="proximity">Proximity Sensor</a> specification defines an API to monitor the presence of nearby objects without physical contact. The <a data-featureid="ambientlight">Ambient Light Sensor</a> specification defines an API to monitor the ambient light level or illuminance of the device's environment..</p>
+          <p>A number of sensor APIs are being built on top of the Generic Sensor API. The <a data-featureid="proximity">Proximity Sensor</a> specification defines an API to monitor the presence of nearby objects without physical contact. The <a data-featureid="ambient-light">Ambient Light Sensor</a> specification defines an API to monitor the ambient light level or illuminance of the device's environment..</p>
 
           <p>The detection of motion is made possible by a combination of low-level and high-level motion sensor specifications, also built on top of the Generic Sensor API:</p>
 

--- a/games/userinput.ja.html
+++ b/games/userinput.ja.html
@@ -58,7 +58,7 @@
         <div data-feature="Sensors">
           <p><a data-featureid="generic-sensor">Generic Sensor API</a> はセンサーからのデータをウェブプラットフォームに統一的な形で公開するためのフレームワークを定義します。特に、この仕様では異なったセンサーに対応させるために拡張可能な抽象化された <code>Sensor</code> インターフェースにより、特定のセンサーについての仕様を作成するための青写真を提供します。</p>
 
-          <p>この Generic Sensor API に基づいて様々なセンサー API が定義されつつあります。<a data-featureid="proximity">Proximity Sensor</a> 仕様は物理的接触がない近接オブジェクトの存在を検出するための API を定義しています。<a data-featureid="ambientlight">Ambient Light Sensor</a> 仕様は背景光レベルや照度を検出するための APIを定義しています。</p>
+          <p>この Generic Sensor API に基づいて様々なセンサー API が定義されつつあります。<a data-featureid="proximity">Proximity Sensor</a> 仕様は物理的接触がない近接オブジェクトの存在を検出するための API を定義しています。<a data-featureid="ambient-light">Ambient Light Sensor</a> 仕様は背景光レベルや照度を検出するための APIを定義しています。</p>
 
           <p>動作の検出は Generic Sensor API の上に定義された低レベル・高レベルのモーションセンサー仕様の組み合わせで実現されています:</p>
 

--- a/mobile/sensors.html
+++ b/mobile/sensors.html
@@ -31,7 +31,7 @@
 
         <p data-feature="Proximity sensors">The <a data-featureid="proximity">Proximity Sensor</a> specification defines an API to monitor the presence of nearby objects without physical contact.</p>
 
-        <p data-feature="Ambient light sensors">The <a data-featureid="ambientlight">Ambient Light Sensor</a> specification defines an API to monitor the ambient light level or illuminance of the device's environment.</p>
+        <p data-feature="Ambient light sensors">The <a data-featureid="ambient-light">Ambient Light Sensor</a> specification defines an API to monitor the ambient light level or illuminance of the device's environment.</p>
 
         <p data-feature="Battery status">The <a data-featureid="battery">Battery Status API</a> exposes information about the battery status of the hosting service (however, note the future of this last specification is uncertain due to identified <a href="https://github.com/w3c/battery/issues/5">potential privacy-invasive usage</a> of the API).</p>
 

--- a/mobile/sensors.zh.html
+++ b/mobile/sensors.zh.html
@@ -31,7 +31,7 @@
 
         <p data-feature="接近度传感器"><a data-featureid="proximity">接近度传感器</a>规范定义了一个API来监控附近物体的存在，而无需物理接触。</p>
 
-        <p data-feature="环境光线传感器"><a data-featureid="ambientlight">环境光线传感器</a>规范定义了一个API来监控环境光照水平。</p>
+        <p data-feature="环境光线传感器"><a data-featureid="ambient-light">环境光线传感器</a>规范定义了一个API来监控环境光照水平。</p>
 
         <p data-feature="电池状态"><a data-featureid="battery">电池状态API</a>公开了有关设备的电池状态信息（但是，请注意，最后一个规范的未来由于其<a href="https://github.com/w3c/battery/issues/5">隐私侵入性</a>还不明朗）。</p>
 

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "web-roadmaps",
   "dependencies": {
     "ajv-cli": "^3.0.0",
+    "browser-specs": "^1.14.0",
     "fetch-filecache-for-crawling": "^3.0.2",
     "jsdom": "^16.2.2",
     "mdn-browser-compat-data": "^1.0.0",


### PR DESCRIPTION
The code already interfaced with the W3C API and specref but, for non /TR/ specs, this required tracking the URL and sometimes the title in the data file, which is error-prone (both may evolve as spec progresses).

browser-specs is an up-to-date and curated list of specifications implemented (or being worked on) by Web browsers. The code now uses at its first source of information. browser-specs does not contain all relevant specs for roadmaps, but that's still a better start.

This update includes a first pass at data files to drop now useless "url" and "title" fields when possible (meaning when the filename matches the shortname of the spec in browser-specs). A second pass will be needed to update the names of the files to the spec shortname where possible, as well as to reference features from within the main spec file instead of maintaining multiple specs for each of them.

The goal with these updates is to reduce the need to maintain data to a bare minimum.