### PR TITLE
[Mobile] Update Data Storage page

### DIFF
--- a/data/storage-access.json
+++ b/data/storage-access.json
@@ -1,0 +1,29 @@
+{
+  "wgs": [
+    {
+      "url": "https://www.w3.org/community/privacycg/",
+      "label": "Privacy Community Group"
+    }
+  ],
+  "publisher": "W3C",
+  "impl": {
+    "chromestatus": 5612590694662144    
+  },
+  "features": {
+    "hasStorageAccess": {
+      "url": "#dom-document-hasstorageaccess",
+      "title": "hasStorageAccess method",
+      "impl": {
+        "mdn": "api.Document.hasStorageAccess"
+      }
+    },
+    "requestStorageAccess": {
+      "url": "#dom-document-requeststorageaccess",
+      "title": "requestStorageAccess method",
+      "impl": {
+        "mdn": "api.Document.requestStorageAccess"
+      }
+    }
+  },
+  "featuresCoverage": "full"
+}

--- a/data/storage-buckets.json
+++ b/data/storage-buckets.json
@@ -1,0 +1,7 @@
+{
+  "url": "https://github.com/WICG/storage-buckets/blob/gh-pages/explainer.md",
+  "title": "Storage Buckets",
+  "impl": {
+    "chromestatus": 5739224579964928
+  }
+}

--- a/mobile/storage.html
+++ b/mobile/storage.html
@@ -23,6 +23,8 @@
       <section class="featureset in-progress">
         <h2>Technologies in progress</h2>
 
+        <p data-feature="Storage management">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space. The <a data-featureid="storage">Storage</a> specification allows Web applications to get quota estimate for storage as well as to request that the data stored by the application be treated as persistent and cannot be evicted without the user’s explicit consent.</p>
+
         <div data-feature="File operations">
           <p>Although the notion is less prevalent on mobile, there is generally at least some sort of concept of a file system. The <a data-featureid="fileapi">File API</a> provides an API for representing file objects in web applications, as well as programmatically selecting them and accessing their data. The API is read-only. Discussions on a read-write API have now resumed, see <a href="#native-file-system">Native File System</a> below.</p>
         </div>
@@ -30,8 +32,6 @@
 
       <section class="featureset exploratory-work">
         <h2>Exploratory work</h2>
-
-        <p data-feature="Quota for storage">As more and more data need to be stored by the browser (e.g. for offline usage), it becomes critical for developers to get reliable storage space. The proposed <a data-featureid="storage">Storage</a> specification will allow Web applications to get quota estimate for storage as well as to request that the data stored by the application be treated as persistent and cannot be evicted without the user’s explicit consent.</p>
 
         <div data-feature="File operations">
           <p>The <a data-featureid="native-file-system">Native File System</a> specification is an early API proposal that lets Websites gain write access to the native file system. It builds on top of the <a href="#fileapi">File API</a>.</p>
@@ -43,6 +43,12 @@
 
         <div data-feature="State management">
           <p>HTTP cookies provide a valuable state-management mechanism for the Web. However, the synchronous nature of the <code>document.cookie</code> interface has been a source of performance issue, especially now that browsers use multiple processes and threads to improve perceived performances and responsiveness where ever possible, including on mobile platforms where processing powers may be more limited. Cookies are also unavailable to workers, which do not have access to the DOM. The <a data-featureid="cookie-store">Cookie Store API</a> defines an asynchronous cookies API for documents and workers.</p>
+        </div>
+
+        <div data-feature="Storage management">
+          <p>Web applications need to store different types of data locally, with different eviction strategies when running out of storage. For instance, application may want to evict images first as they can be retrieved from the network, but may want to preserve application state as much as possible. The <a data-featureid="storage-buckets">Storage buckets</a> proposal grants applications the ability to create multiple storage buckets, where the user agent may choose to delete each bucket independently of other buckets.</p>
+
+          <p>The <a data-featureid="storage-access">Storage Access API</a> enables content inside <code>&lt;iframe&gt;</code> elements to request and be granted access to their client-side storage, provided user agrees to it, so that embedded content which relies on having access to client-side storage can work in browsers that would otherwise prevent this behavior, e.g. to preserve the user's privacy.</p>
         </div>
       </section>
 


### PR DESCRIPTION
- Move Storage to specifications in progress (fix #485). Not going to well-deployed given lack of support in Safari
- Mention Storage Buckets (fix #493)
- Mention the Storage Access API (developed in Privacy CG, see #492)