### PR TITLE
[Mobile] Mention guidelines docs in Security and Privacy

### DIFF
--- a/mobile/security.html
+++ b/mobile/security.html
@@ -10,7 +10,7 @@
 
       <p>Mobile devices follow their users everywhere, and hold some of their most private or confidential data (contacts, pictures, calendar, etc.) As a result, it is critical for users to be able to rely on their phones to keep that data safe from attackers.</p>
 
-      <p>W3C specifications are reviewed for their security and privacy impact as part of their progress through the Recommendation track; the <a href="https://www.w3.org/Privacy/">Privacy Interest Group</a> and the <a href="https://www.w3.org/Security/wiki/IG">Web Security Interest Group</a> in particular are coordinating reviews on their respective fields.</p>
+      <p>W3C specifications are reviewed for their security and privacy impact as part of their progress through the Recommendation track. The <a href="https://www.w3.org/TR/security-privacy-questionnaire/">Self-Review Questionnaire: Security and Privacy</a> and the <a href="https://www.w3.org/TR/fingerprinting-guidance/">Mitigating Browser Fingerprinting in Web Specifications</a> documents provide guidance to help groups evaluate the impact of the technologies they develop and explore threat mitigation strategies when necessary.</p>
 
       <p>Security and privacy technologies listed below have a particular resonance in a mobile context. Please check the <a href="https://w3c.github.io/web-roadmaps/security/">Security roadmap</a> document for a more comprehensive overview of security on the Web.</p>
     </header>


### PR DESCRIPTION
The update also drops mentions of the Interest Groups.

Fix #460.