### PR TITLE
[mobile] Add changelog for September 2020 release

### DIFF
--- a/js/template-about.html
+++ b/js/template-about.html
@@ -101,10 +101,6 @@
           <td>Chrome</td>
         </tr>
         <tr>
-          <td><img src="../assets/impl/edge.png" alt="Edge"></td>
-          <td>Microsoft Edge</td>
-        </tr>
-        <tr>
           <td><img src="../assets/impl/firefox.png" alt="Firefox"></td>
           <td>Firefox</td>
         </tr>
@@ -120,6 +116,10 @@
         <tr>
           <td><img src="../assets/impl/baidu.png" alt="Baidu Browser"></td>
           <td>Baidu Browser</td>
+        </tr>
+        <tr>
+          <td><img src="../assets/impl/edge.png" alt="Edge"></td>
+          <td>Microsoft Edge</td>
         </tr>
         <tr>
           <td><img src="../assets/impl/opera.png" alt="Opera"></td>

--- a/js/template-about.zh.html
+++ b/js/template-about.zh.html
@@ -101,10 +101,6 @@
           <td>Chrome</td>
         </tr>
         <tr>
-          <td><img src="../assets/impl/edge.png" alt="Edge"></td>
-          <td>Microsoft Edge</td>
-        </tr>
-        <tr>
           <td><img src="../assets/impl/firefox.png" alt="Firefox"></td>
           <td>Firefox</td>
         </tr>
@@ -120,6 +116,10 @@
         <tr>
           <td><img src="../assets/impl/baidu.png" alt="百度浏览器"></td>
           <td>百度浏览器</td>
+        </tr>
+        <tr>
+          <td><img src="../assets/impl/edge.png" alt="Edge"></td>
+          <td>Microsoft Edge</td>
         </tr>
         <tr>
           <td><img src="../assets/impl/opera.png" alt="Opera"></td>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -14,7 +14,7 @@
         <h2>Change History</h2>
         <section>
           <h3>September 2020</h3>
-          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot adds a few new proposals being incubated in various W3C community groups, some new deliverables from various W3C working groups, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
+          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot aadds new W3C community groups incubations, new W3C working group deliverables, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
           <dl>
             <dt>Exploratory work</dt>
             <dd><ul>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -21,13 +21,21 @@
               <li>Mention High Dynamic Range and Wide Gamut Color on the Web in <a data-page="media"></a></li>
               <li>Mention User-Agent Client Hints in <a data-page="adaptation"></a></li>
               <li>Mention Storage buckets in <a data-page="storage"></a></li>
-              <li>Mention Storage Access API in <a data-page="storage"></a></li>
+              <li>Mention Storage Access API in <a data-page="storage"></a> and <a data-page="security"></a></li>
               <li>Mention performance.measureMemory API in <a data-page="performance"></a></li>
               <li>Mention main thread scheduling APIs in <a data-page="performance"></a></li>
               <li>Mention requestPostAnimationFrame in <a data-page="performance"></a></li>
               <li>Mention Web Locks API in <a data-page="storage"></a> and <a data-page="lifecycle"></a></li>
               <li>Mention User Idle Detection in <a data-page="lifecycle"></a></li>
               <li>Mention MiniApps in <a data-page="lifecycle"></a></li>
+              <li>Mention isLoggedIn in <a data-page="security"></a></li>
+              <li>Mention Trust Token API in <a data-page="security"></a></li>
+              <li>Mention First-Party Sets in <a data-page="security"></a></li>
+              <li>Mention Private Click Measurement in <a data-page="security"></a></li>
+              <li>Mention JS Isolation via Origin Labels and Membranes in <a data-page="security"></a></li>
+              <li>Mention TURTLEDOVE in <a data-page="security"></a></li>
+              <li>Mention SPARROW in <a data-page="security"></a></li>
+              <li>Mention Web Monetization in <a data-page="payment"></a></li>
             </ul></dd>
 
             <dt>Technologies in progress</dt>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -13,6 +13,48 @@
       <section>
         <h2>Change History</h2>
         <section>
+          <h3>September 2020</h3>
+          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot adds a few new proposals being incubated in various W3C community groups, some new deliverables from various W3C working groups, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
+          <dl>
+            <dt>Exploratory work</dt>
+            <dd><ul>
+              <li>Mention High Dynamic Range and Wide Gamut Color on the Web in <a data-page="media"></a></li>
+              <li>Mention User-Agent Client Hints in <a data-page="adaptation"></a></li>
+              <li>Mention Storage buckets in <a data-page="storage"></a></li>
+              <li>Mention Storage Access API in <a data-page="storage"></a></li>
+              <li>Mention performance.measureMemory API in <a data-page="performance"></a></li>
+              <li>Mention main thread scheduling APIs in <a data-page="performance"></a></li>
+              <li>Mention requestPostAnimationFrame in <a data-page="performance"></a></li>
+              <li>Mention Web Locks API in <a data-page="storage"></a> and <a data-page="lifecycle"></a></li>
+              <li>Mention User Idle Detection in <a data-page="lifecycle"></a></li>
+              <li>Mention MiniApps in <a data-page="lifecycle"></a></li>
+            </ul></dd>
+
+            <dt>Technologies in progress</dt>
+            <dd><ul>
+              <li>Mention Constructable Stylesheet Objects in <a data-page="adaptation"></a></li>
+              <li>Mention new CSS media features in <a data-page="adaptation"></a></li>
+              <li>Mention Web App Manifest - Application Information in <a data-page="lifecycle"></a></li>
+              <li>Move Badging API to technologies in progress in <a data-page="lifecycle"></a> and <a data-page="userinput"></a></li>
+              <li>Move Web Share Target API to technologies in progress in <a data-page="lifecycle"></a></li>
+              <li>Move WebGPU to technologies in progress in <a data-page="graphics"></a></li>
+              <li>Move the Storage specification to technologies in progress in <a data-page="storage"></a></li>
+              <li>Move Open Screen Protocol to technologies in progress in <a data-page="media"></a></li>
+              <li>Rename Feature Policy to Permissions Policy in <a data-page="security"></a></li>
+            </ul></dd>
+
+            <dt>Well-deployed technologies</dt>
+            <dd><ul>
+              <li>Mention HTML/CSS Ruby in <a data-page="graphics"></a></li>
+              <li>Move main Web components specifications to well-deployed technologies in <a data-page="adaptation"></a></li>
+            </ul></dd>
+          </dl>
+          <p>The implementation info has also been updated to reflect known implementation status in September 2020. Some of these updates may have been triggered by updates to underlying platform status sites. Main updates are:</p>
+          <ul>
+            <!-- TODO: Should we mention the implementation status changes in Edge? There are many, many, changes to the implementation status in this update because of the EdgeHTML/Chakra->Blink/V8 switch. -->
+          </ul>
+        </section>
+        <section>
           <h3>November 2019</h3>
           <p>The <a href="https://www.w3.org/2019/11/web-roadmaps/mobile/">November 2019</a> snapshot adds a few new proposals being incubated in the Web Platform Incubator Community Group, some new deliverables from various W3C working groups, and refreshes the status of other specifications. Changes made since the April 2019 snapshot:</p>
           <dl>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -60,7 +60,9 @@
           </dl>
           <p>The implementation info has also been updated to reflect known implementation status in September 2020. Some of these updates may have been triggered by updates to underlying platform status sites. Main updates are:</p>
           <ul>
-            <!-- TODO: Should we mention the implementation status changes in Edge? There are many, many, changes to the implementation status in this update because of the EdgeHTML/Chakra->Blink/V8 switch. -->
+            <li>Implementation info for Edge now targets the latest version of Edge, based on Chromium. A number of features that were not supported or in development correctly appear as shipped in Edge as a result</li>
+            <li>Web Components technologies are now well supported across main browsers, see <a data-page="adaptation"></a></li>
+            <li>Web Animations has shipped in Safari and is now available across main browsers, see <a data-page="graphics"></a></li>
           </ul>
         </section>
         <section>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -40,6 +40,7 @@
               <li>Move WebGPU to technologies in progress in <a data-page="graphics"></a></li>
               <li>Move the Storage specification to technologies in progress in <a data-page="storage"></a></li>
               <li>Move Open Screen Protocol to technologies in progress in <a data-page="media"></a></li>
+              <li>Move WebTransport to technologies in progress in <a data-page="network"></a></li>
               <li>Rename Feature Policy to Permissions Policy in <a data-page="security"></a></li>
             </ul></dd>
 

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -14,7 +14,7 @@
         <h2>Change History</h2>
         <section>
           <h3>September 2020</h3>
-          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot aadds new W3C community groups incubations, new W3C working group deliverables, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
+          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot adds new W3C community groups incubations, new W3C working group deliverables, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
           <dl>
             <dt>Exploratory work</dt>
             <dd><ul>


### PR DESCRIPTION
Should we mention the implementation status changes in Edge? There are many, many, changes to the implementation status of Edge in this update because of the EdgeHTML/Chakra->Blink/V8 switch, so listing them one by one may be too long. Perhaps we just need to summarize it in one sentence?

I'll add the Chinese translation after this PR is merged.

(I also moved Edge from "Main browser engines" to "Based on the main browser engines".)