### PR TITLE
Chrome Platform Status: ignore prefixed/flag once shipped

### DIFF
--- a/data/mse.json
+++ b/data/mse.json
@@ -9,29 +9,6 @@
   "impl": {
     "caniuse": "mediasource",
     "chromestatus": 4563797888991232,
-    "edgestatus": "Media Source Extensions",
-    "other": [
-      {
-        "ua": "chrome",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2020-09-10",
-        "comment": "The JSON export of Chrome status incorrectly flags MSE as prefixed, see https://github.com/GoogleChrome/chromium-dashboard/issues/1006"
-      },
-      {
-        "ua": "chrome_android",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2020-09-10",
-        "comment": "The JSON export of Chrome status incorrectly flags MSE as prefixed, see https://github.com/GoogleChrome/chromium-dashboard/issues/1006"
-      },
-      {
-        "ua": "edge",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2020-09-10",
-        "comment": "The JSON export of Chrome status incorrectly flags MSE as prefixed, see https://github.com/GoogleChrome/chromium-dashboard/issues/1006"
-      }
-    ]
+    "edgestatus": "Media Source Extensions"
   }
 }

--- a/data/webaudio.json
+++ b/data/webaudio.json
@@ -3,30 +3,7 @@
     "caniuse": "audio-api",
     "chromestatus": 6261718720184320,
     "edgestatus": "Web Audio API",
-    "webkitstatus": "feature-web-audio",
-    "other": [
-      {
-        "ua": "chrome",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2019-12-02",
-        "comment": "The JSON export of Chrome status incorrectly flags the Web Audio API as prefixed, see https://github.com/w3c/web-roadmaps/issues/427"
-      },
-      {
-        "ua": "chrome_android",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2019-12-02",
-        "comment": "The JSON export of Chrome status incorrectly flags the Web Audio API as prefixed, see https://github.com/w3c/web-roadmaps/issues/427"
-      },
-      {
-        "ua": "edge",
-        "status": "shipped",
-        "source": "feedback",
-        "date": "2020-09-10",
-        "comment": "The JSON export of Chrome status incorrectly flags the Web Audio API as prefixed, see https://github.com/w3c/web-roadmaps/issues/427"
-      }
-    ]
+    "webkitstatus": "feature-web-audio"
   },
   "features": {
     "worklet": {

--- a/tools/extract-impl-data.js
+++ b/tools/extract-impl-data.js
@@ -224,14 +224,17 @@ let sources = {
             console.warn(`- Unknown chrome status ${status}`);
             break;
         }
-        if (chromestatus.prefixed) {
-          res.prefix = true;
-        }
-        if (chromestatus.flag || (status === 'Behind a flag')) {
-          res.flag = true;
-        }
-        if ((res.status === 'shipped') && (res.prefix || res.flag)) {
-          res.status = 'experimental';
+
+        // The "prefixed" and "flag" properties are no longer maintained once a
+        // feature has shipped, see discussion in :
+        // https://github.com/GoogleChrome/chromium-dashboard/issues/1006
+        if (res.status !== 'shipped') {
+          if (chromestatus.prefixed) {
+            res.prefix = true;
+          }
+          if (chromestatus.flag || (status === 'Behind a flag')) {
+            res.flag = true;
+          }
         }
         res.source = source;
         res.href = `https://www.chromestatus.com/feature/${key}`;


### PR DESCRIPTION
Properties are no longer maintained in Chrome Platform Status once a feature has shipped. This update makes the code ignore the `prefixed` and `flag` properties when the Chrome Platform Status entry reports that the feature is "Enabled by default".

This means that the code will no longer think that Chrome only has experimental and prefixed support for the Web Audio API and MSE.

See https://github.com/GoogleChrome/chromium-dashboard/issues/1006

Also fixes #427 for good. No further need to hardcode the implementation status for the Web Audio API.