### PR TITLE
[Mobile] Move WebTransport to spec in progress

### DIFF
--- a/data/web-transport.json
+++ b/data/web-transport.json
@@ -1,2 +1,8 @@
 {
+  "wgs": [
+    {
+      "url": "https://www.w3.org/groups/wg/webtransport",
+      "label": "WebTransport Working Group"
+    }
+  ]
 }

--- a/mobile/network.html
+++ b/mobile/network.html
@@ -54,6 +54,10 @@
         <div data-feature="P2P Data Connections">
           <p>The work on <a data-featureid="p2p">Web Real-Time Communications</a> also provides direct <strong>peer-to-peer data connections</strong> between browsers with real-time characteristics, opening the way to collaborative multi-devices Web applications.</p>
         </div>
+
+        <div data-feature="Bidirectional Connections">
+          <p>The <a data-featureid="web-transport">WebTransport</a> proposal would allow data to be sent and received between a browser and server, implementing pluggable protocols underneath with common APIs on top, notably based on QUIC. The API is similar to WebSocket in that it exposes bidirectional connections between a client and a server, but allows to further reduce the latency of network communications between a client and a server, and also supports multiple streams, unidirectional streams, out-of-order delivery, and unreliable transport. Usage scenarios include sending the state of a game with minimal latency to a server repeatedly using unreliable and out-of-order messages, low-latency streaming of media chunks from a server to a client, and cloud based scenarios where most of the application logic runs on the server.</p>
+        </div>
       </section>
 
       <section class="featureset exploratory-work">
@@ -67,10 +71,6 @@
 
         <div data-feature="Network Characteristics">
           <p>Discontinued work on the <a data-featureid="netinfo">Network Information API</a> to address discovery of the network characteristics has now been resumed in the Web Platform Incubator Community Group.</p>
-        </div>
-
-        <div data-feature="Bidirectional Connections">
-          <p>The <a data-featureid="web-transport">WebTransport</a> proposal would allow data to be sent and received between a browser and server, implementing pluggable protocols underneath with common APIs on top, notably based on QUIC. The API is similar to WebSocket in that it exposes bidirectional connections between a client and a server, but allows to further reduce the latency of network communications between a client and a server, and also supports multiple streams, unidirectional streams, out-of-order delivery, and unreliable transport. Usage scenarios include sending the state of a game with minimal latency to a server repeatedly using unreliable and out-of-order messages, low-latency streaming of media chunks from a server to a client, and cloud based scenarios where most of the application logic runs on the server.</p>
         </div>
       </section>   
     </main>

--- a/mobile/network.zh.html
+++ b/mobile/network.zh.html
@@ -54,6 +54,10 @@
         <div data-feature="点对点数据连接">
           <p><a data-featureid="p2p">Web 实时通讯</a>方面的工作还提供了具有实时特性的浏览器之间的直接<strong>点对点数据连接</strong>，为协作式多设备的 Web 应用开辟了道路。</p>
         </div>
+
+        <div data-feature="双向连接">
+          <p><a data-featureid="web-transport">WebTransport</a> 提案将允许在浏览器和服务器之间发送和接收数据，并在顶部使用常见 API 来实现其下的可插拔协议（尤其是基于QUIC）。该 API 与 WebSocket 相似，也是客户端和服务器的双向连接，但允许进一步减少客户端和服务器之间的网络通信延迟，并且还支持多个流、单向流、乱序和不可靠传输。使用场景包括使用不可靠且乱序的消息向服务器重复发送低延迟的游戏状态、从服务器到客户端的媒体片段的低延迟传输以及大多数逻辑在服务器上运行的云场景。</p>
+        </div>
       </section>
 
       <section class="featureset exploratory-work">
@@ -67,10 +71,6 @@
         <div data-feature="网络特性">
           <p>Web 平台孵化社区组重新恢复了之前停止的可以解决网络特性的发现问题的<a data-featureid="netinfo">网络信息 API</a> 的工作。</p>
         </div>
-
-        <div data-feature="双向连接">
-            <p><a data-featureid="web-transport">WebTransport</a> 提案将允许在浏览器和服务器之间发送和接收数据，并在顶部使用常见 API 来实现其下的可插拔协议（尤其是基于QUIC）。该 API 与 WebSocket 相似，也是客户端和服务器的双向连接，但允许进一步减少客户端和服务器之间的网络通信延迟，并且还支持多个流、单向流、乱序和不可靠传输。使用场景包括使用不可靠且乱序的消息向服务器重复发送低延迟的游戏状态、从服务器到客户端的媒体片段的低延迟传输以及大多数逻辑在服务器上运行的云场景。</p>
-          </div>
       </section>
     </main>
     <script src="../js/generate.js"></script>


### PR DESCRIPTION
The WebTransport Working Group was created this week to standardize the WebTransport API. The spec has not yet migrated out of WICG, but that should happen soon.