### PR TITLE
[Mobile] Add new privacy explorations

### DIFF
--- a/data/first-party-sets.json
+++ b/data/first-party-sets.json
@@ -1,0 +1,13 @@
+{
+  "url": "https://github.com/privacycg/first-party-sets",
+  "title": "First-Party Sets",
+  "wgs": [
+    {
+      "label": "Privacy Community Group",
+      "url": "https://privacycg.github.io/"
+    }
+  ],
+  "impl": {
+    "chromestatus": 5640066519007232
+  }
+}

--- a/data/is-logged-in.json
+++ b/data/is-logged-in.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/privacycg/is-logged-in",
+  "title": "IsLoggedIn",
+  "wgs": [
+    {
+      "label": "Privacy Community Group",
+      "url": "https://privacycg.github.io/"
+    }
+  ]
+}

--- a/data/js-membranes.json
+++ b/data/js-membranes.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://github.com/privacycg/js-membranes",
+  "title": "JS Isolation via Origin Labels and Membranes",
+  "wgs": [
+    {
+      "label": "Privacy Community Group",
+      "url": "https://privacycg.github.io/"
+    }
+  ]
+}

--- a/data/private-click-measurement.json
+++ b/data/private-click-measurement.json
@@ -1,0 +1,10 @@
+{
+  "url": "https://privacycg.github.io/private-click-measurement/",
+  "title": "Private Click Measurement",
+  "wgs": [
+    {
+      "label": "Privacy Community Group",
+      "url": "https://privacycg.github.io/"
+    }
+  ]
+}

--- a/data/sparrow.json
+++ b/data/sparrow.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/WICG/sparrow",
+  "title": "SPARROW"
+}

--- a/data/trust-token-api.json
+++ b/data/trust-token-api.json
@@ -1,0 +1,8 @@
+{
+  "url": "https://github.com/WICG/trust-token-api",
+  "title": "Trust Token API",
+  "impl": {
+    "chromestatus": 5078049450098688
+  }
+}
+

--- a/data/turtledove.json
+++ b/data/turtledove.json
@@ -1,0 +1,4 @@
+{
+  "url": "https://github.com/WICG/turtledove",
+  "title": "TURTLEDOVE"
+}

--- a/mobile/security.html
+++ b/mobile/security.html
@@ -72,6 +72,20 @@
         <div data-feature="Permissions">
           <p>Different APIs use different mechanisms to grant permission to use or access an underlying powerful feature. To ease design of permission-related code, the <a data-featureid="permissions-request">Requesting permissions</a> and <a data-featureid="permissions-revoke">Relinquishing permissions</a> proposals extend the <a href="https://www.w3.org/TR/permissions/">Permissions API</a> to provide a uniform function for requesting and revoking permission to use powerful features.</p>
         </div>
+
+        <div data-feature="Strengthened privacy">
+          <p>Main browser vendors progressively introduce more stringent rules for technologies that may be abused to track users without their consent. One example is third-party cookies which are being phased out from main browsers. Several proposals are being discussed to replace these technologies and otherwise extend the Web platform with solutions that give users control on whether sites may track them:</p>
+          <ul>
+            <li><a data-featureid="is-logged-in">isLoggedIn</a> for websites to inform the web browser of the user's login state and allow browsers to restrict features such as long term storage and cookies to scenarios where the user is logged in.</li>
+            <li><a data-featureid="trust-token-api">Trust Token API</a> to propagate trust across sites, using the <a href="https://privacypass.github.io/">Privacy Pass</a> protocol as an underlying primitive.</li>
+            <li><a data-featureid="first-party-sets">First-Party Sets</a> to declare a collection of related domains as being in a first-party set</li>
+            <li><a data-featureid="private-click-measurement">Private Click Measurement</a> to attribute a conversion, such as a purchase or a sign-up, to a previous ad click in a privacy preserving way.</li>
+            <li><a data-featureid="js-membranes">JS Isolation via Origin Labels and Membranes</a> to allow an application to include remote code without giving that code access to all of the capabilities of the including origin, including document, navigator and other related Web API and DOM defined interfaces.</li>
+            <li>The <a data-featureid="storage-access">Storage Access API</a> to give a way for content inside <code>&lt;iframe&gt;</code> elements to request and be granted access to their client-side storage, provided user agrees to it, so that embedded content which relies on having access to client-side storage can work in browsers that would otherwise prevent this behavior to preserve the user's privacy.</li>
+            <li><a data-featureid="turtledove">TURTLEDOVE</a> to put the browser, not the advertiser, in control of the information about what the advertiser thinks a person is interested in.</li>
+            <li><a data-featureid="sparrow">SPARROW</a>, which builds on top of TURTLEDOVE, and gives advertisers more control over the user experience, whilst keeping privacy guarantees.</li>
+          </ul>
+        </div>
       </section>
 
       <section>

--- a/tools/extract-impl-data.js
+++ b/tools/extract-impl-data.js
@@ -218,6 +218,7 @@ let sources = {
           case 'Removed':
           case 'Deprecated':
           case 'Defer':
+          case 'Harmful':
             res.status = '';
             break;
           default:


### PR DESCRIPTION
This updates the security and privacy page to mention the plan to drop third-party cookies and ongoing explorations in the Privacy CG and in the WICG find replacements and to strengthen privacy on the Web.

The update also accounts for the "Harmful" status reported by Chrome Platform Status for the implementation status of "First-party Sets" in Firefox.

Fixes #492.