### PR TITLE
[Mobile] Add new page to list features mentioned per group

### DIFF
--- a/js/generate-utils.js
+++ b/js/generate-utils.js
@@ -496,9 +496,11 @@ const createMentionCell = function (column, refId, featureName, specInfo, implIn
     cell.innerHTML = featureName;
   }
   pages.forEach((page, pos) => {
+    const localizedUrl = ((lang === 'en') ? page.url :
+      page.url.replace(/\.([^\.]+)$/, '.' + lang + '.$1'));
     cell.innerHTML += ((pos > 0 || featureName) ? '<br/>' : '') +
       seeLabel.replace('%page',
-        '<a href="' + page.url + '">' + page.title + '</a>');
+        '<a href="' + localizedUrl + '">' + page.title + '</a>');
   });
   cell.classList.add('mention');
   return cell;

--- a/js/template-groups.zh.html
+++ b/js/template-groups.zh.html
@@ -1,0 +1,8 @@
+<div id="intro">
+  <p>
+    This page summarizes groups mentioned throughout this document's pages, along with the name of the specifications and features that these groups are (or were) responsible for. Please refer to individual pages for details about the relevance and status of each work.
+  </p>
+</div>
+<section id="table">
+  <h2>List of groups</h2>
+</section>

--- a/mobile/about.html
+++ b/mobile/about.html
@@ -14,7 +14,7 @@
         <h2>Change History</h2>
         <section>
           <h3>September 2020</h3>
-          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot adds new W3C community groups incubations, new W3C working group deliverables, and refreshes the status of other specifications. Changes made since the November 2019 snapshot:</p>
+          <p>The <a href="https://www.w3.org/2020/09/web-roadmaps/mobile/">September 2020</a> snapshot adds new W3C community groups incubations, new W3C working group deliverables, and refreshes the status of other specifications. The snapshot also features a new <a href="groups.html">groups page</a> that summarizes the list of groups, specifications and mentions that appear throughout the roadmap. Changes made to individual pages since the November 2019 snapshot:</p>
           <dl>
             <dt>Exploratory work</dt>
             <dd><ul>

--- a/mobile/groups.html
+++ b/mobile/groups.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>List of relevant groups</title>
+  </head>
+  <body>
+    <header>
+      <h1>List of relevant groups</h1>
+    </header>
+    <main data-contents="groups"></main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>

--- a/mobile/groups.zh.html
+++ b/mobile/groups.zh.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="zh">
+  <head>
+    <meta charset="utf-8">
+    <title>List of relevant groups</title>
+  </head>
+  <body>
+    <header>
+      <h1>List of relevant groups</h1>
+    </header>
+    <main data-contents="groups"></main>
+    <script src="../js/generate.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
This update creates a new groups page, which appears in the overall menu, that provides a groups' perspective on features mentioned throughout the roadmap.

This gives people who are wondering what particular groups are working on a good overview of features of interest that these groups develop.

Not that this does not add a link on the home page. The groups page remains a bit hidden in the side menu. That's mostly on purpose, the page should be more useful for "advanced" readers, and is less human-friendly since

@xfq Sorry for the last-minute addition. Just realized that we could enable that feature for the mobile roadmap as well. For info, that feature was requested by media folks, and enabled in the media version of the roadmap: https://w3c.github.io/web-roadmaps/media/groups.html. I thought that could be useful for mobile as well. The `.zh.html` files in the PR need to be translated (and the Chinese version of the changelog needs to be slightly updated).