### PR TITLE
Support new CR Draft and Snapshot statuses

### DIFF
--- a/tools/extract-spec-data.js
+++ b/tools/extract-spec-data.js
@@ -36,6 +36,8 @@ const maturities = [
 const maturityMapping = {
   'Working Draft': 'WD',
   'Candidate Recommendation': 'CR',
+  'Candidate Recommendation Draft': 'CR',
+  'Candidate Recommendation Snapshot': 'CR',
   'Proposed Recommendation': 'PR',
   'Recommendation': 'REC',
   'LastCall': 'WD',


### PR DESCRIPTION
These new statuses were introduced in Process 2020.

I note that we may want to highlight CR drafts and snapshots differently in the future. Not done here!