### PR TITLE
Bump versions of dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
-sudo: false
 language: node_js
 node_js:
 - node
+cache:
+  npm: false
 script:
 - bash "./deploy.sh"
 env:

--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "web-roadmaps",
   "dependencies": {
     "ajv-cli": "^3.0.0",
-    "browser-specs": "^1.14.0",
+    "browser-specs": "^1.19.1",
     "fetch-filecache-for-crawling": "^3.0.2",
     "jsdom": "^16.2.2",
-    "mdn-browser-compat-data": "^1.0.0",
+    "mdn-browser-compat-data": "^1.1.1",
     "mkdirp": "^0.5.1",
     "ncp": "^2.0.0"
   },


### PR DESCRIPTION
For some reason, Travis CI does not seem to obey the `^` prefix and at least fails to load the latest version of browser-specs.